### PR TITLE
Update value objects to more closely mimic original value objects

### DIFF
--- a/bundle/Templating/Twig/Extension/FieldRenderingExtension.php
+++ b/bundle/Templating/Twig/Extension/FieldRenderingExtension.php
@@ -45,6 +45,7 @@ class FieldRenderingExtension extends Twig_Extension
                 'ng_render_field',
                 function (Twig_Environment $environment, Field $field, array $params = []) {
                     $this->fieldBlockRenderer->setTwig($environment);
+
                     return $this->renderField($field, $params);
                 },
                 [
@@ -96,7 +97,7 @@ class FieldRenderingExtension extends Twig_Extension
 
         $content = $field->content->innerContent;
         $contentType = $field->content->contentInfo->innerContentType;
-        $fieldDefinition = $contentType->getFieldDefinition($field->identifier);
+        $fieldDefinition = $contentType->getFieldDefinition($field->fieldDefIdentifier);
 
         $params += [
             'field' => $field->innerField,

--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read string $name
  * @property-read string|int $mainLocationId
  * @property-read \Netgen\EzPlatformSite\API\Values\ContentInfo $contentInfo
+ * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
  * @property-read \Netgen\EzPlatformSite\API\Values\Field[] $fields
  * @property-read \eZ\Publish\API\Repository\Values\Content\Content $innerContent
  */

--- a/lib/API/Values/ContentInfo.php
+++ b/lib/API/Values/ContentInfo.php
@@ -10,11 +10,23 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * Corresponds to eZ Platform Repository ContentInfo object.
  * @see \eZ\Publish\API\Repository\Values\Content\ContentInfo
  *
- * @property-read string|int $id
- * @property-read string|int $mainLocationId
- * @property-read string $contentTypeIdentifier
+ * @property-read int|string $id
+ * @property-read int|string $contentTypeId
+ * @property-read int|string $sectionId
+ * @property-read int $currentVersionNo
+ * @property-read bool $published
+ * @property-read int|string $ownerId
+ * @property-read \DateTime $modificationDate
+ * @property-read \DateTime $publishedDate
+ * @property-read bool $alwaysAvailable
+ * @property-read string $remoteId
+ * @property-read string $mainLanguageCode
+ * @property-read int|string $mainLocationId
  * @property-read string $name
  * @property-read string $languageCode
+ * @property-read string $contentTypeIdentifier
+ * @property-read string $contentTypeName
+ * @property-read string $contentTypeDescription
  * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $innerContentInfo
  * @property-read \eZ\Publish\API\Repository\Values\ContentType\ContentType $innerContentType
  */

--- a/lib/API/Values/Field.php
+++ b/lib/API/Values/Field.php
@@ -11,11 +11,12 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @see \eZ\Publish\API\Repository\Values\Content\Field
  *
  * @property-read string|int $id
- * @property-read string $identifier
+ * @property-read string $fieldDefIdentifier
+ * @property-read \eZ\Publish\SPI\FieldType\Value $value
+ * @property-read string $languageCode
  * @property-read string $fieldTypeIdentifier
  * @property-read string $name
  * @property-read string $description
- * @property-read \eZ\Publish\SPI\FieldType\Value $value
  * @property-read \Netgen\EzPlatformSite\API\Values\Content $content
  * @property-read \eZ\Publish\API\Repository\Values\Content\Field $innerField
  * @property-read \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $innerFieldDefinition

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -10,8 +10,19 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * Corresponds to eZ Platform Repository Location object.
  * @see \eZ\Publish\API\Repository\Values\Content\Location
  *
- * @property-read string|int $id
- * @property-read string|int $parentLocationId
+ * @property-read int|string $id
+ * @property-read int $status
+ * @property-read int $priority
+ * @property-read bool $hidden
+ * @property-read bool $invisible
+ * @property-read string $remoteId
+ * @property-read int|string $parentLocationId
+ * @property-read string $pathString
+ * @property-read int[] $path
+ * @property-read int $depth
+ * @property-read int $sortField
+ * @property-read int $sortOrder
+ * @property-read int|string $contentId
  * @property-read \eZ\Publish\API\Repository\Values\Content\Location $innerLocation
  * @property-read \Netgen\EzPlatformSite\API\Values\ContentInfo $contentInfo
  */

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -6,6 +6,8 @@ use Netgen\EzPlatformSite\API\Values\ContentInfo as APIContentInfo;
 
 final class ContentInfo extends APIContentInfo
 {
+    use TranslatableTrait;
+
     /**
      * @var string
      */
@@ -36,12 +38,24 @@ final class ContentInfo extends APIContentInfo
     public function __get($property)
     {
         switch ($property) {
-            case 'id':
-                return $this->innerContentInfo->id;
-            case 'mainLocationId':
-                return $this->innerContentInfo->mainLocationId;
             case 'contentTypeIdentifier':
                 return $this->innerContentType->identifier;
+            case 'contentTypeName':
+                return $this->getTranslatedString(
+                    $this->languageCode,
+                    (array)$this->innerContentType->getNames()
+                );
+            case 'contentTypeDescription':
+                return $this->getTranslatedString(
+                    $this->languageCode,
+                    (array)$this->innerContentType->getDescriptions()
+                );
+        }
+
+        if (property_exists($this, $property)) {
+            return $this->$property;
+        } elseif (property_exists($this->innerContentInfo, $property)) {
+            return $this->innerContentInfo->$property;
         }
 
         return parent::__get($property);
@@ -57,10 +71,14 @@ final class ContentInfo extends APIContentInfo
     public function __isset($property)
     {
         switch ($property) {
-            case 'id':
-            case 'mainLocationId':
             case 'contentTypeIdentifier':
+            case 'contentTypeName':
+            case 'contentTypeDescription':
                 return true;
+        }
+
+        if (property_exists($this, $property) || property_exists($this->innerContentInfo, $property)) {
+            return true;
         }
 
         return parent::__isset($property);

--- a/lib/Core/Site/Values/ContentTrait.php
+++ b/lib/Core/Site/Values/ContentTrait.php
@@ -81,6 +81,12 @@ trait ContentTrait
                 return $this->contentInfo->mainLocationId;
         }
 
+        if (property_exists($this, $property)) {
+            return $this->$property;
+        } elseif (property_exists($this->innerContent, $property)) {
+            return $this->innerContent->$property;
+        }
+
         return parent::__get($property);
     }
 
@@ -100,6 +106,10 @@ trait ContentTrait
                 return true;
         }
 
+        if (property_exists($this, $property) || property_exists($this->innerContent, $property)) {
+            return true;
+        }
+
         return parent::__isset($property);
     }
 
@@ -108,7 +118,7 @@ trait ContentTrait
         $properties['content'] = $this;
         $field = new Field($properties);
 
-        $this->fields[$field->identifier] = $field;
+        $this->fields[$field->fieldDefIdentifier] = $field;
         $this->fieldsById[$field->id] = $field;
     }
 }

--- a/lib/Core/Site/Values/Field.php
+++ b/lib/Core/Site/Values/Field.php
@@ -6,6 +6,8 @@ use Netgen\EzPlatformSite\API\Values\Field as APIField;
 
 final class Field extends APIField
 {
+    use TranslatableTrait;
+
     /**
      * @var bool
      */
@@ -47,17 +49,11 @@ final class Field extends APIField
     public function __get($property)
     {
         switch ($property) {
-            case 'id':
-                return $this->innerField->id;
-            case 'identifier':
-                return $this->innerField->fieldDefIdentifier;
             case 'fieldTypeIdentifier':
                 return $this->innerFieldDefinition->fieldTypeIdentifier;
-            case 'value':
-                return $this->innerField->value;
             case 'innerFieldDefinition':
                 return $this->content->contentInfo->innerContentType->getFieldDefinition(
-                    $this->identifier
+                    $this->innerField->fieldDefIdentifier
                 );
             case 'name':
                 return $this->getTranslatedString(
@@ -69,6 +65,12 @@ final class Field extends APIField
                     $this->content->contentInfo->languageCode,
                     (array)$this->innerFieldDefinition->getDescriptions()
                 );
+        }
+
+        if (property_exists($this, $property)) {
+            return $this->$property;
+        } elseif (property_exists($this->innerField, $property)) {
+            return $this->innerField->$property;
         }
 
         return parent::__get($property);
@@ -84,25 +86,17 @@ final class Field extends APIField
     public function __isset($property)
     {
         switch ($property) {
-            case 'id':
-            case 'identifier':
             case 'fieldTypeIdentifier':
-            case 'value':
             case 'innerFieldDefinition':
             case 'name':
             case 'description':
                 return true;
         }
 
-        return parent::__isset($property);
-    }
-
-    private function getTranslatedString($languageCode, $strings)
-    {
-        if (array_key_exists($languageCode, $strings)) {
-            return $strings[$languageCode];
+        if (property_exists($this, $property) || property_exists($this->innerField, $property)) {
+            return true;
         }
 
-        return null;
+        return parent::__isset($property);
     }
 }

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -26,10 +26,14 @@ final class Location extends APILocation
     public function __get($property)
     {
         switch ($property) {
-            case 'id':
-                return $this->innerLocation->id;
-            case 'parentLocationId':
-                return $this->innerLocation->parentLocationId;
+            case 'contentId':
+                return $this->contentInfo->id;
+        }
+
+        if (property_exists($this, $property)) {
+            return $this->$property;
+        } elseif (property_exists($this->innerLocation, $property)) {
+            return $this->innerLocation->$property;
         }
 
         return parent::__get($property);
@@ -45,9 +49,12 @@ final class Location extends APILocation
     public function __isset($property)
     {
         switch ($property) {
-            case 'id':
-            case 'parentLocationId':
+            case 'contentId':
                 return true;
+        }
+
+        if (property_exists($this, $property) || property_exists($this->innerLocation, $property)) {
+            return true;
         }
 
         return parent::__isset($property);

--- a/lib/Core/Site/Values/TranslatableTrait.php
+++ b/lib/Core/Site/Values/TranslatableTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Netgen\EzPlatformSite\Core\Site\Values;
+
+/**
+ * @internal
+ */
+trait TranslatableTrait
+{
+    private function getTranslatedString($languageCode, $strings)
+    {
+        if (array_key_exists($languageCode, $strings)) {
+            return $strings[$languageCode];
+        }
+
+        return null;
+    }
+}

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -333,7 +333,7 @@ class BaseTest extends APIBaseTest
         $field = $content->getField($identifier);
 
         $this->assertSame($data['isEmpty'], $field->isEmpty());
-        $this->assertSame($identifier, $field->identifier);
+        $this->assertSame($identifier, $field->fieldDefIdentifier);
         $this->assertSame($data['fieldTypeIdentifier'], $field->fieldTypeIdentifier);
     }
 

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -4,6 +4,8 @@ namespace Netgen\EzPlatformSite\Tests\Integration;
 
 use Netgen\EzPlatformSite\API\Values\Content;
 use eZ\Publish\API\Repository\Tests\BaseTest as APIBaseTest;
+use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
+use DateTime;
 
 /**
  * Base class for API integration tests.
@@ -27,7 +29,27 @@ class BaseTest extends APIBaseTest
             'locationId' => 60,
             'locationRemoteId' => '86bf306624668ee9b8b979b0d56f7e0d',
             'parentLocationId' => 2,
+            'locationPriority' => -2,
+            'locationHidden' => false,
+            'locationInvisible' => false,
+            'locationPathString' => '/1/2/60/',
+            'locationPath' => [1, 2, 60],
+            'locationDepth' => 2,
+            'locationSortField' => APILocation::SORT_FIELD_PRIORITY,
+            'locationSortOrder' => APILocation::SORT_ORDER_ASC,
             'contentTypeIdentifier' => 'feedback_form',
+            'contentTypeId' => 20,
+            'sectionId' => 1,
+            'currentVersionNo' => 1,
+            'published' => true,
+            'ownerId' => 14,
+            'modificationDateTimestamp' => 1332927282,
+            'publishedDateTimestamp' => 1332927205,
+            'alwaysAvailable' => false,
+            'mainLanguageCode' => 'eng-GB',
+            'mainLocationId' => 60,
+            'contentTypeName' => 'Feedback form',
+            'contentTypeDescription' => '',
             'languageCode' => 'eng-GB',
             'fields' => [
                 'description' => [
@@ -78,7 +100,27 @@ class BaseTest extends APIBaseTest
             'locationId' => 56,
             'locationRemoteId' => '772da20ecf88b3035d73cbdfcea0f119',
             'parentLocationId' => 58,
+            'locationPriority' => 0,
+            'locationHidden' => false,
+            'locationInvisible' => false,
+            'locationPathString' => '/1/58/56/',
+            'locationPath' => [1, 58, 56],
+            'locationDepth' => 2,
+            'locationSortField' => APILocation::SORT_FIELD_PATH,
+            'locationSortOrder' => APILocation::SORT_ORDER_ASC,
             'contentTypeIdentifier' => 'template_look',
+            'contentTypeId' => 15,
+            'sectionId' => 5,
+            'currentVersionNo' => 3,
+            'published' => true,
+            'ownerId' => 14,
+            'modificationDateTimestamp' => 100,
+            'publishedDateTimestamp' => 1082016652,
+            'alwaysAvailable' => false,
+            'mainLanguageCode' => 'eng-US',
+            'mainLocationId' => 56,
+            'contentTypeName' => '',
+            'contentTypeDescription' => '',
             'languageCode' => 'ger-DE',
             'fields' => [
                 'email' => [
@@ -173,7 +215,27 @@ class BaseTest extends APIBaseTest
             'locationId' => 5,
             'locationRemoteId' => '3f6d92f8044aed134f32153517850f5a',
             'parentLocationId' => 1,
+            'locationPriority' => 0,
+            'locationHidden' => false,
+            'locationInvisible' => false,
+            'locationPathString' => '/1/5/',
+            'locationPath' => [1, 5],
+            'locationDepth' => 1,
+            'locationSortField' => APILocation::SORT_FIELD_PATH,
+            'locationSortOrder' => APILocation::SORT_ORDER_ASC,
             'contentTypeIdentifier' => 'user_group',
+            'contentTypeId' => 3,
+            'sectionId' => 2,
+            'currentVersionNo' => 1,
+            'published' => true,
+            'ownerId' => 14,
+            'modificationDateTimestamp' => 1033917596,
+            'publishedDateTimestamp' => 1033917596,
+            'alwaysAvailable' => true,
+            'mainLanguageCode' => 'eng-US',
+            'mainLocationId' => 5,
+            'contentTypeName' => 'User group',
+            'contentTypeDescription' => '',
             'languageCode' => 'eng-US',
             'fields' => [
                 'description' => [
@@ -204,7 +266,27 @@ class BaseTest extends APIBaseTest
             'locationId' => 54,
             'locationRemoteId' => 'fa9f3cff9cf90ecfae335718dcbddfe2',
             'parentLocationId' => null,
+            'locationPriority' => null,
+            'locationHidden' => null,
+            'locationInvisible' => null,
+            'locationPathString' => null,
+            'locationPath' => null,
+            'locationDepth' => null,
+            'locationSortField' => null,
+            'locationSortOrder' => null,
             'contentTypeIdentifier' => null,
+            'contentTypeId' => null,
+            'sectionId' => null,
+            'currentVersionNo' => null,
+            'published' => null,
+            'ownerId' => null,
+            'modificationDateTimestamp' => null,
+            'publishedDateTimestamp' => null,
+            'alwaysAvailable' => null,
+            'mainLanguageCode' => null,
+            'mainLocationId' => null,
+            'contentTypeName' => null,
+            'contentTypeDescription' => null,
             'languageCode' => null,
             'fields' => null,
             'isFound' => false,
@@ -278,30 +360,42 @@ class BaseTest extends APIBaseTest
         $this->assertContentInfo($content->contentInfo, $data);
         $this->assertFields($content, $data);
         $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Content', $content->innerContent);
+        $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\VersionInfo', $content->versionInfo);
     }
 
     protected function assertContentInfo($contentInfo, $data)
     {
-        list($name, $contentId, , $locationId, , , $contentTypeIdentifier, $languageCode) = array_values($data);
+        list($name, $contentId, $contentRemoteId, $locationId) = array_values($data);
 
         /** @var \Netgen\EzPlatformSite\API\Values\ContentInfo $contentInfo */
         $this->assertInstanceOf('\Netgen\EzPlatformSite\API\Values\ContentInfo', $contentInfo);
 
         $this->assertEquals($contentId, $contentInfo->id);
+        $this->assertEquals($contentRemoteId, $contentInfo->remoteId);
         $this->assertEquals($locationId, $contentInfo->mainLocationId);
-        $this->assertEquals($contentTypeIdentifier, $contentInfo->contentTypeIdentifier);
         $this->assertEquals($name, $contentInfo->name);
-        $this->assertEquals($languageCode, $contentInfo->languageCode);
+        $this->assertEquals($data['contentTypeIdentifier'], $contentInfo->contentTypeIdentifier);
+        $this->assertEquals($data['contentTypeId'], $contentInfo->contentTypeId);
+        $this->assertEquals($data['sectionId'], $contentInfo->sectionId);
+        $this->assertEquals($data['currentVersionNo'], $contentInfo->currentVersionNo);
+        $this->assertEquals($data['published'], $contentInfo->published);
+        $this->assertEquals($data['ownerId'], $contentInfo->ownerId);
+        $this->assertEquals($data['modificationDateTimestamp'], $contentInfo->modificationDate->getTimestamp());
+        $this->assertEquals($data['publishedDateTimestamp'], $contentInfo->publishedDate->getTimestamp());
+        $this->assertEquals($data['alwaysAvailable'], $contentInfo->alwaysAvailable);
+        $this->assertEquals($data['mainLanguageCode'], $contentInfo->mainLanguageCode);
+        $this->assertEquals($data['mainLocationId'], $contentInfo->mainLocationId);
+        $this->assertEquals($data['contentTypeName'], $contentInfo->contentTypeName);
+        $this->assertEquals($data['contentTypeDescription'], $contentInfo->contentTypeDescription);
+        $this->assertEquals($data['languageCode'], $contentInfo->languageCode);
         $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\ContentInfo', $contentInfo->innerContentInfo);
         $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\ContentType\ContentType', $contentInfo->innerContentType);
     }
 
     protected function assertFields(Content $content, $data)
     {
-        list(, , , , , , , , $expectedFields) = array_values($data);
-
         $this->assertInternalType('array', $content->fields);
-        $this->assertCount(count($expectedFields), $content->fields);
+        $this->assertCount(count($data['fields']), $content->fields);
 
         foreach ($content->fields as $identifier => $field) {
             $this->assertInstanceOf('\Netgen\EzPlatformSite\API\Values\Field', $field);
@@ -323,29 +417,40 @@ class BaseTest extends APIBaseTest
             $this->assertSame($content, $field->content);
         }
 
-        foreach ($expectedFields as $identifier => $data) {
-            $this->assertField($content, $identifier, $data);
+        foreach ($data['fields'] as $identifier => $fieldData) {
+            $this->assertField($content, $identifier, $data['languageCode'], $fieldData);
         }
     }
 
-    protected function assertField(Content $content, $identifier, $data)
+    protected function assertField(Content $content, $identifier, $languageCode, $data)
     {
         $field = $content->getField($identifier);
 
         $this->assertSame($data['isEmpty'], $field->isEmpty());
         $this->assertSame($identifier, $field->fieldDefIdentifier);
         $this->assertSame($data['fieldTypeIdentifier'], $field->fieldTypeIdentifier);
+        $this->assertEquals($languageCode, $field->languageCode);
     }
 
     protected function assertLocation($location, $data)
     {
-        list(, , , $locationId, , $parentLocationId) = array_values($data);
+        list(, , , $locationId, $locationRemoteId, $parentLocationId) = array_values($data);
 
         /** @var \Netgen\EzPlatformSite\API\Values\Location $location */
         $this->assertInstanceOf('\Netgen\EzPlatformSite\API\Values\Location', $location);
 
         $this->assertEquals($locationId, $location->id);
+        $this->assertEquals($locationRemoteId, $location->remoteId);
         $this->assertEquals($parentLocationId, $location->parentLocationId);
+        $this->assertEquals(APILocation::STATUS_PUBLISHED, $location->status);
+        $this->assertEquals($data['locationPriority'], $location->priority);
+        $this->assertEquals($data['locationHidden'], $location->hidden);
+        $this->assertEquals($data['locationInvisible'], $location->invisible);
+        $this->assertEquals($data['locationPathString'], $location->pathString);
+        $this->assertEquals($data['locationPath'], $location->path);
+        $this->assertEquals($data['locationDepth'], $location->depth);
+        $this->assertEquals($data['locationSortField'], $location->sortField);
+        $this->assertEquals($data['locationSortOrder'], $location->sortOrder);
         $this->assertContentInfo($location->contentInfo, $data);
         $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Location', $location->innerLocation);
     }
@@ -368,6 +473,10 @@ class BaseTest extends APIBaseTest
         $contentUpdateStruct = $contentService->newContentUpdateStruct();
         $contentUpdateStruct->setField('my_profile_label', 'Das Titel', 'ger-DE');
         $updatedDraft = $contentService->updateContent($draft->versionInfo, $contentUpdateStruct);
-        $contentService->publishVersion($updatedDraft->versionInfo);
+        $content = $contentService->publishVersion($updatedDraft->versionInfo);
+
+        $contentMetadataUpdateStruct = $contentService->newContentMetadataUpdateStruct();
+        $contentMetadataUpdateStruct->modificationDate = new DateTime('@100');
+        $contentService->updateContentMetadata($content->contentInfo, $contentMetadataUpdateStruct);
     }
 }

--- a/tests/lib/Integration/FindServiceBaseTest.php
+++ b/tests/lib/Integration/FindServiceBaseTest.php
@@ -79,7 +79,7 @@ class FindServiceBaseTest extends BaseTest
             return;
         }
 
-        list(, , , , , , , $languageCode) = array_values($data);
+        $languageCode = $data['languageCode'];
 
         $this->assertSame(1, $searchResult->totalCount);
         $this->assertSame($languageCode, $searchResult->searchHits[0]->matchedTranslation);
@@ -94,7 +94,7 @@ class FindServiceBaseTest extends BaseTest
             return;
         }
 
-        list(, , , , , , , $languageCode) = array_values($data);
+        $languageCode = $data['languageCode'];
 
         $this->assertSame(1, $searchResult->totalCount);
         $this->assertSame($languageCode, $searchResult->searchHits[0]->matchedTranslation);
@@ -109,7 +109,7 @@ class FindServiceBaseTest extends BaseTest
             return;
         }
 
-        list(, , , , , , , $languageCode) = array_values($data);
+        $languageCode = $data['languageCode'];
 
         $this->assertSame(1, $searchResult->totalCount);
         $this->assertSame($languageCode, $searchResult->searchHits[0]->matchedTranslation);
@@ -124,7 +124,7 @@ class FindServiceBaseTest extends BaseTest
             return;
         }
 
-        list(, , , , , , , $languageCode) = array_values($data);
+        $languageCode = $data['languageCode'];
 
         $this->assertSame(1, $searchResult->totalCount);
 


### PR DESCRIPTION
This allows less code modifications once the Site API is activated.

Once the override for default controller action is activated, this also saves time by requiring less changes to Twig templates.

Included in PR also:
- Renamed `$field->identifier` to `$field->fieldDefIdentifier` for above reason
- Added `$location->contentId` for above reason
- Added convenience properties to fetch translated content type name and content type description in content info

TODO:
- [x] Update tests
