### PR TITLE
Remove possibility to configure view action

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -30,10 +30,6 @@ class Configuration extends SiteAccessConfiguration
         $systemNode
             ->booleanNode('override_url_alias_view_action')
                 ->info('Whether to override URL alias view action')
-            ->end()
-            ->scalarNode('url_alias_view_action')
-                ->info('URL alias view action')
-                ->example('ng_content:viewAction')
             ->end();
     }
 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -9,7 +9,6 @@ parameters:
 
     # Defaults for semantic configuration
     netgen_ez_platform_site_api.default.override_url_alias_view_action: false
-    netgen_ez_platform_site_api.default.url_alias_view_action: 'ng_content:viewAction'
 
 services:
     netgen.ezplatform_site.core.find_service:

--- a/bundle/Routing/UrlAliasRouter.php
+++ b/bundle/Routing/UrlAliasRouter.php
@@ -7,20 +7,18 @@ use Symfony\Component\HttpFoundation\Request;
 
 class UrlAliasRouter extends BaseUrlAliasRouter
 {
+    const OVERRIDE_VIEW_ACTION = 'ng_content:viewAction';
+
     public function matchRequest(Request $request)
     {
         $parameters = parent::matchRequest($request);
-        $override = $this->configResolver->getParameter(
+        $overrideViewAction = $this->configResolver->getParameter(
             'override_url_alias_view_action',
             'netgen_ez_platform_site_api'
         );
-        $viewAction = $this->configResolver->getParameter(
-            'url_alias_view_action',
-            'netgen_ez_platform_site_api'
-        );
 
-        if ($override && !empty($viewAction)) {
-            $parameters['_controller'] = $viewAction;
+        if ($overrideViewAction) {
+            $parameters['_controller'] = self::OVERRIDE_VIEW_ACTION;
         }
 
         return $parameters;


### PR DESCRIPTION
Overriding the view action can effectively disable the content view builder due
to how matching is done on which view builder will be used (it checks for hardcoded `ng_content:` prefix).

After merging, https://github.com/netgen/ezplatform-site-api/pull/9 needs to be rebased.
