### PR TITLE
Add base controller which other controllers can extend

### DIFF
--- a/bundle/Controller/Controller.php
+++ b/bundle/Controller/Controller.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller as BaseController;
+
+abstract class Controller extends BaseController
+{
+    /**
+     * @return \Netgen\EzPlatformSite\API\Site
+     */
+    public function getSite()
+    {
+        return $this->container->get('netgen.ezplatform_site.site');
+    }
+
+    /**
+     * Returns the root location object for current siteaccess configuration.
+     *
+     * @return \Netgen\EzPlatformSite\API\Values\Location
+     */
+    public function getRootLocation()
+    {
+        $rootLocation = parent::getRootLocation();
+
+        return $this->getSite()->getLoadService()->loadLocation($rootLocation->id);
+    }
+}

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -14,6 +14,12 @@ parameters:
     netgen_ez_platform_site_api.default.override_url_alias_view_action: false
 
 services:
+    netgen.ezplatform_site.controller.base:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Controller\Controller
+        abstract: true
+        calls:
+            - [setContainer, ["@service_container"]]
+
     netgen.ezplatform_site.core.find_service:
         class: Netgen\EzPlatformSite\Core\Site\FindService
         arguments:


### PR DESCRIPTION
When writing controllers, I find myself always injecting find service and load service over and over again.

This adds a base controller much like eZ and Symfony base controllers with helper method to load site API.

Also overriden is the method to load root location, which returns site API location now.
