### PR TITLE
Set API services to be lazy initialized

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -22,6 +22,7 @@ services:
 
     netgen.ezplatform_site.core.find_service:
         class: Netgen\EzPlatformSiteApi\Core\Site\FindService
+        lazy: true
         arguments:
             - '@netgen.ezplatform_site.core.domain_object_mapper'
             - '@ezpublish.api.service.search'
@@ -31,6 +32,7 @@ services:
 
     netgen.ezplatform_site.core.load_service:
         class: Netgen\EzPlatformSiteApi\Core\Site\LoadService
+        lazy: true
         arguments:
             - '@netgen.ezplatform_site.core.domain_object_mapper'
             - '@ezpublish.api.service.content'

--- a/lib/Core/Site/FindService.php
+++ b/lib/Core/Site/FindService.php
@@ -8,7 +8,7 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 
-final class FindService implements FindServiceInterface
+class FindService implements FindServiceInterface
 {
     /**
      * @var \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper

--- a/lib/Core/Site/LoadService.php
+++ b/lib/Core/Site/LoadService.php
@@ -9,7 +9,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 
-final class LoadService implements LoadServiceInterface
+class LoadService implements LoadServiceInterface
 {
     /**
      * @var \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -6,7 +6,7 @@ use Netgen\EzPlatformSiteApi\API\FindService as FindServiceInterface;
 use Netgen\EzPlatformSiteApi\API\LoadService as LoadServiceInterface;
 use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
 
-final class Site implements SiteInterface
+class Site implements SiteInterface
 {
     /**
      * @var \Netgen\EzPlatformSiteApi\API\FindService

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -12,6 +12,7 @@ services:
 
     netgen.ezplatform_site.core.find_service:
         class: Netgen\EzPlatformSiteApi\Core\Site\FindService
+        lazy: true
         arguments:
             - '@netgen.ezplatform_site.core.domain_object_mapper'
             - '@ezpublish.api.service.search'
@@ -21,6 +22,7 @@ services:
 
     netgen.ezplatform_site.core.load_service:
         class: Netgen\EzPlatformSiteApi\Core\Site\LoadService
+        lazy: true
         arguments:
             - '@netgen.ezplatform_site.core.domain_object_mapper'
             - '@ezpublish.api.service.content'
@@ -30,6 +32,7 @@ services:
 
     netgen.ezplatform_site.core.site:
         class: Netgen\EzPlatformSiteApi\Core\Site\Site
+        lazy: true
         arguments:
             - '@netgen.ezplatform_site.find_service'
             - '@netgen.ezplatform_site.load_service'

--- a/lib/Resources/config/services.yml
+++ b/lib/Resources/config/services.yml
@@ -12,4 +12,3 @@ services:
 
     netgen.ezplatform_site.site:
         alias: 'netgen.ezplatform_site.core.site'
-        lazy: true


### PR DESCRIPTION
When site API is used in services which are initialized before siteaccess is matched (for example event listeners), the site breaks due to inability to load template/controller override rules.

Unfortunately, to make the services lazy, they cannot be defined as `final`.

This follows how eZ repository is also specified as lazy, precisely for this reason.
