### PR TITLE
Add ng_image_alias twig function

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -61,3 +61,9 @@ services:
             - '@ezpublish.fieldType.parameterProviderRegistry'
         tags:
             - {name: twig.extension}
+
+    netgen.ezplatform_site.twig.extension.image:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageExtension
+        arguments: ['@ezpublish.fieldtype.ezimage.variation_service']
+        tags:
+            - { name: twig.extension }

--- a/bundle/Templating/Twig/Extension/ImageExtension.php
+++ b/bundle/Templating/Twig/Extension/ImageExtension.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
+
+use eZ\Publish\API\Repository\Exceptions\InvalidVariationException;
+use Netgen\EzPlatformSiteApi\API\Values\Field;
+use eZ\Publish\Core\MVC\Exception\SourceImageNotFoundException;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use Twig_Extension;
+use Twig_SimpleFunction;
+use InvalidArgumentException;
+
+class ImageExtension extends Twig_Extension
+{
+    /**
+     * @var VariationHandler
+     */
+    private $imageVariationService;
+
+    public function __construct(VariationHandler $imageVariationService)
+    {
+        $this->imageVariationService = $imageVariationService;
+    }
+
+    public function getName()
+    {
+        return 'netgen.image';
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            new Twig_SimpleFunction(
+                'ng_image_alias',
+                array($this, 'getImageVariation'),
+                array('is_safe' => array('html'))
+            ),
+        );
+    }
+
+    /**
+     * Returns the image variation object for $field/$versionInfo.
+     *
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field
+     * @param string $variationName
+     *
+     * @return \eZ\Publish\SPI\Variation\Values\Variation
+     */
+    public function getImageVariation(Field $field, $variationName)
+    {
+        try {
+            return $this->imageVariationService->getVariation($field->innerField, $field->content->versionInfo, $variationName);
+        } catch (InvalidVariationException $e) {
+            if (isset($this->logger)) {
+                $this->logger->error("Couldn't get variation '{$variationName}' for image with id {$field->value->id}");
+            }
+        } catch (SourceImageNotFoundException $e) {
+            if (isset($this->logger)) {
+                $this->logger->error(
+                    "Couldn't create variation '{$variationName}' for image with id {$field->value->id} because source image can't be found"
+                );
+            }
+        } catch (InvalidArgumentException $e) {
+            if (isset($this->logger)) {
+                $this->logger->error(
+                    "Couldn't create variation '{$variationName}' for image with id {$field->value->id} because an image could not be created from the given input"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds `ng_image_alias` Twig extension, similar to `ng_render_field` so we don't have to call `ez_image_alias` over and over again with `ez_image_alias(content.fields.my_field.innerField, content.versionInfo, 'my_image_alias')`.

This way, we only have to do `ng_image_alias(content.fields.my_field, 'my_image_alias')`
