### PR TITLE
Fix notice in content view when no location or content are available

### DIFF
--- a/bundle/View/ContentView.php
+++ b/bundle/View/ContentView.php
@@ -31,6 +31,10 @@ class ContentView extends BaseContentView implements ContentValueView
 
     public function getContent()
     {
+        if (!$this->content instanceof Content) {
+            return null;
+        }
+
         return $this->content->innerContent;
     }
 
@@ -41,6 +45,10 @@ class ContentView extends BaseContentView implements ContentValueView
 
     public function getLocation()
     {
+        if (!$this->location instanceof Location) {
+            return null;
+        }
+
         return $this->location->innerLocation;
     }
 


### PR DESCRIPTION
Depending on how `ng_content:viewAction` or `ng_content:embedAction` are called, some of the objects may not exist in content view.
