### PR TITLE
Use custom view providers, to be able to use ngcontent_view override rules

### DIFF
--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\ContentView as BaseContentView;
+
+class ContentView extends BaseContentView
+{
+    const NODE_KEY = 'ngcontent_view';
+    const INFO = 'Template selection settings when displaying a content with Netgen Site API';
+}

--- a/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
@@ -33,6 +33,7 @@ class NetgenEzPlatformSiteApiExtension extends Extension
         $fileLocator = new FileLocator(__DIR__ . '/../Resources/config');
         $loader = new Loader\YamlFileLoader($container, $fileLocator);
         $loader->load('services.yml');
+        $loader->load('view.yml');
 
         $processor = new ConfigurationProcessor($container, $this->getAlias());
         $processor->mapConfig(

--- a/bundle/NetgenEzPlatformSiteApiBundle.php
+++ b/bundle/NetgenEzPlatformSiteApiBundle.php
@@ -5,6 +5,7 @@ namespace Netgen\Bundle\EzPlatformSiteApiBundle;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\DefaultViewActionOverridePass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\PreviewControllerOverridePass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\ViewBuilderRegistrationPass;
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Configuration\Parser\ContentView;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -17,5 +18,9 @@ class NetgenEzPlatformSiteApiBundle extends Bundle
         $container->addCompilerPass(new DefaultViewActionOverridePass());
         $container->addCompilerPass(new PreviewControllerOverridePass());
         $container->addCompilerPass(new ViewBuilderRegistrationPass());
+
+        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $coreExtension */
+        $coreExtension = $container->getExtension('ezpublish');
+        $coreExtension->addConfigParser(new ContentView());
     }
 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -40,15 +40,6 @@ services:
             - '$languages$'
             - '%netgen.ezplatform_site.use_always_available%'
 
-    netgen.ezplatform_site.view_builder.content:
-        class: Netgen\Bundle\EzPlatformSiteApiBundle\View\Builder\ContentViewBuilder
-        arguments:
-            - '@netgen.ezplatform_site.site'
-            - '@ezpublish.api.repository'
-            - '@security.authorization_checker'
-            - '@ezpublish.view.configurator'
-            - '@ezpublish.view.view_parameters.injector.dispatcher'
-
     netgen.ezplatform_site.controller.content.view:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Controller\Content\ViewController
         parent: ezpublish.controller.base

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -1,0 +1,39 @@
+parameters:
+    # Default settings for ngcontent_view template rules
+    ezsettings.default.ngcontent_view: {}
+
+services:
+    netgen.ezplatform_site.view_builder.content:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\View\Builder\ContentViewBuilder
+        arguments:
+            - '@netgen.ezplatform_site.site'
+            - '@ezpublish.api.repository'
+            - '@security.authorization_checker'
+            - '@ezpublish.view.configurator'
+            - '@ezpublish.view.view_parameters.injector.dispatcher'
+
+    netgen.ezplatform_site.ngcontent_view_provider.configured:
+        class: "%ezpublish.view_provider.configured.class%"
+        arguments: ["@netgen.ezplatform_site.ngcontent_view.matcher_factory"]
+        tags:
+            - {name: ezpublish.view_provider, type: 'Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView', priority: 110}
+
+    netgen.ezplatform_site.ngcontent_view.matcher_factory:
+        class: "%ezpublish.view.matcher_factory.class%"
+        arguments: ["@ezpublish.api.repository", 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
+        calls:
+            - [setContainer, ["@service_container"]]
+            - [setMatchConfig, [$ngcontent_view$]]
+
+    netgen.ezplatform_site.content_view_provider.configured:
+        class: "%ezpublish.view_provider.configured.class%"
+        arguments: ["@netgen.ezplatform_site.content_view.matcher_factory"]
+        tags:
+            - {name: ezpublish.view_provider, type: 'Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView', priority: 100}
+
+    netgen.ezplatform_site.content_view.matcher_factory:
+        class: "%ezpublish.view.matcher_factory.class%"
+        arguments: ["@ezpublish.api.repository", 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
+        calls:
+            - [setContainer, ["@service_container"]]
+            - [setMatchConfig, [$content_view$]]

--- a/bundle/View/ContentView.php
+++ b/bundle/View/ContentView.php
@@ -6,13 +6,16 @@ use Netgen\EzPlatformSiteApi\API\Values\Content;
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use Netgen\EzPlatformSiteApi\API\Values\Location;
-use eZ\Publish\Core\MVC\Symfony\View\ContentView as BaseContentView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\EmbedView;
+use eZ\Publish\Core\MVC\Symfony\View\CachableView;
 use RuntimeException;
 
 /**
  * Builds ContentView objects.
  */
-class ContentView extends BaseContentView implements ContentValueView
+class ContentView extends BaseView implements View, ContentValueView, LocationValueView, EmbedView, CachableView
 {
     /**
      * @var \Netgen\EzPlatformSiteApi\API\Values\Content
@@ -23,6 +26,11 @@ class ContentView extends BaseContentView implements ContentValueView
      * @var \Netgen\EzPlatformSiteApi\API\Values\Location|null
      */
     private $location;
+
+    /**
+     * @var bool
+     */
+    private $isEmbed = false;
 
     public function setSiteContent(Content $content)
     {
@@ -90,5 +98,24 @@ class ContentView extends BaseContentView implements ContentValueView
         throw new RuntimeException(
             'setLocation method cannot be used with Site API content view. Use setSiteLocation method instead.'
         );
+    }
+
+    /**
+     * Sets the value as embed / not embed.
+     *
+     * @param bool $value
+     */
+    public function setIsEmbed($value)
+    {
+        $this->isEmbed = (bool)$value;
+    }
+
+    /**
+     * Is the view an embed or not.
+     * @return bool True if the view is an embed, false if it is not.
+     */
+    public function isEmbed()
+    {
+        return $this->isEmbed;
     }
 }

--- a/bundle/View/LocationValueView.php
+++ b/bundle/View/LocationValueView.php
@@ -2,9 +2,9 @@
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\View;
 
-use eZ\Publish\Core\MVC\Symfony\View\ContentValueView as BaseContentValueView;
+use eZ\Publish\Core\MVC\Symfony\View\LocationValueView as BaseLocationValueView;
 
-interface ContentValueView extends BaseContentValueView
+interface LocationValueView extends BaseLocationValueView
 {
     /**
      * Returns the Site Location.


### PR DESCRIPTION
This adds the ability to use `ngcontent_view` template override rules when using Site API, by implementing custom view providers, to allow `ez_content:viewAction` to work without having to fallback to Site API specific templates:

You can now have the following config:

```
ezpublish:
    system:
        frontend_group:
            ngcontent_view:
                full:
                    frontpage:
                        template: "NetgenSiteBundle:content/full/siteapi:frontpage.html.twig"
                        match:
                            Identifier\ContentType: frontpage
            content_view:
                full:
                    frontpage:
                        template: "NetgenSiteBundle:content/full:frontpage.html.twig"
                        match:
                            Identifier\ContentType: frontpage
```

To facilitate this, Site API `ContentView` does not extend from base `ContentView` any more, since view providers are selected based on view object class and extending from base view would mean that original view providers would be used instead of our custom ones.

It is also backwards compatible (aside from changes to `ContentView` object and it's interfaces), meaning, if `ngcontent_view` rules do not exist, Site API rendering will fallback to `content_view` rules.