### PR TITLE
Introduce FilterService

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -20,6 +20,16 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
 
+    netgen.ezplatform_site.core.filter_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\FilterService
+        lazy: true
+        arguments:
+            - '@netgen.ezplatform_site.core.domain_object_mapper'
+            - '@netgen.ezplatform_site.repository.filter_service'
+            - '@ezpublish.api.service.content'
+            - '$languages$'
+            - '%netgen.ezplatform_site.use_always_available%'
+
     netgen.ezplatform_site.core.find_service:
         class: Netgen\EzPlatformSiteApi\Core\Site\FindService
         lazy: true

--- a/lib/API/FilterService.php
+++ b/lib/API/FilterService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\API;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+/**
+ * Filters service provides methods for filters entities using
+ * eZ Platform Repository Search Query API.
+ *
+ * In difference to FindService, FilterService always uses synchronous search engine.
+ */
+interface FilterService
+{
+    /**
+     * Filters Content objects for the given $query.
+     *
+     * @see \Netgen\EzPlatformSiteApi\API\Values\Content
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    public function filterContent(Query $query);
+
+    /**
+     * Filters ContentInfo objects for the given $query.
+     *
+     * @see \Netgen\EzPlatformSiteApi\API\Values\ContentInfo
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    public function filterContentInfo(Query $query);
+
+    /**
+     * Filters Location objects for the given $query.
+     *
+     * @see \Netgen\EzPlatformSiteApi\API\Values\Location
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    public function filterLocations(LocationQuery $query);
+}

--- a/lib/API/Site.php
+++ b/lib/API/Site.php
@@ -8,6 +8,13 @@ namespace Netgen\EzPlatformSiteApi\API;
 interface Site
 {
     /**
+     * FilterService getter.
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\FilterService
+     */
+    public function getFilterService();
+
+    /**
      * FindService getter.
      *
      * @return \Netgen\EzPlatformSiteApi\API\FindService

--- a/lib/Core/Site/FilterService.php
+++ b/lib/Core/Site/FilterService.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site;
+
+use Netgen\EzPlatformSiteApi\API\FilterService as FilterServiceInterface;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+class FilterService implements FilterServiceInterface
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper
+     */
+    private $domainObjectMapper;
+
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    private $searchService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var array
+     */
+    private $prioritizedLanguages;
+
+    /**
+     * @var bool
+     */
+    private $useAlwaysAvailable;
+
+    /**
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper $domainObjectMapper
+     * @param \eZ\Publish\API\Repository\SearchService $searchService
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param array $prioritizedLanguages
+     * @param bool $useAlwaysAvailable
+     */
+    public function __construct(
+        DomainObjectMapper $domainObjectMapper,
+        SearchService $searchService,
+        ContentService $contentService,
+        array $prioritizedLanguages,
+        $useAlwaysAvailable
+    ) {
+        $this->domainObjectMapper = $domainObjectMapper;
+        $this->searchService = $searchService;
+        $this->contentService = $contentService;
+        $this->prioritizedLanguages = $prioritizedLanguages;
+        $this->useAlwaysAvailable = $useAlwaysAvailable;
+    }
+
+    public function filterContent(Query $query)
+    {
+        $searchResult = $this->searchService->findContentInfo(
+            $query,
+            [
+                'languages' => $this->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+            ]
+        );
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo */
+            $contentInfo = $searchHit->valueObject;
+            $searchHit->valueObject = $this->domainObjectMapper->mapContent(
+                $this->contentService->loadContent(
+                    $contentInfo->id,
+                    [$searchHit->matchedTranslation]
+                ),
+                $searchHit->matchedTranslation
+            );
+        }
+
+        return $searchResult;
+    }
+
+    public function filterContentInfo(Query $query)
+    {
+        $searchResult = $this->searchService->findContentInfo(
+            $query,
+            [
+                'languages' => $this->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+            ]
+        );
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo */
+            $contentInfo = $searchHit->valueObject;
+            $searchHit->valueObject = $this->domainObjectMapper->mapContentInfo(
+                $this->contentService->loadVersionInfo(
+                    $contentInfo,
+                    $contentInfo->currentVersionNo
+                ),
+                $searchHit->matchedTranslation
+            );
+        }
+
+        return $searchResult;
+    }
+
+    public function filterLocations(LocationQuery $query)
+    {
+        $searchResult = $this->searchService->findLocations(
+            $query,
+            [
+                'languages' => $this->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+            ]
+        );
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            /** @var \eZ\Publish\API\Repository\Values\Content\Location $location */
+            $location = $searchHit->valueObject;
+            $searchHit->valueObject = $this->domainObjectMapper->mapLocation(
+                $location,
+                $this->contentService->loadVersionInfo(
+                    $location->contentInfo,
+                    $location->contentInfo->currentVersionNo
+                ),
+                $searchHit->matchedTranslation
+            );
+        }
+
+        return $searchResult;
+    }
+}

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -2,12 +2,18 @@
 
 namespace Netgen\EzPlatformSiteApi\Core\Site;
 
-use Netgen\EzPlatformSiteApi\API\FindService as FindServiceInterface;
-use Netgen\EzPlatformSiteApi\API\LoadService as LoadServiceInterface;
+use Netgen\EzPlatformSiteApi\API\FilterService;
+use Netgen\EzPlatformSiteApi\API\FindService;
+use Netgen\EzPlatformSiteApi\API\LoadService;
 use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
 
 class Site implements SiteInterface
 {
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FilterService
+     */
+    private $filterService;
+
     /**
      * @var \Netgen\EzPlatformSiteApi\API\FindService
      */
@@ -18,12 +24,24 @@ class Site implements SiteInterface
      */
     private $loadService;
 
+    /**
+     * @param \Netgen\EzPlatformSiteApi\API\FilterService $filterService
+     * @param \Netgen\EzPlatformSiteApi\API\FindService $findService
+     * @param \Netgen\EzPlatformSiteApi\API\LoadService $loadService
+     */
     public function __construct(
-        FindServiceInterface $findService,
-        LoadServiceInterface $loadService
+        FilterService $filterService,
+        FindService $findService,
+        LoadService $loadService
     ) {
+        $this->filterService = $filterService;
         $this->findService = $findService;
         $this->loadService = $loadService;
+    }
+
+    public function getFilterService()
+    {
+        return $this->filterService;
     }
 
     public function getFindService()

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -2,9 +2,9 @@
 
 namespace Netgen\EzPlatformSiteApi\Core\Site;
 
-use Netgen\EzPlatformSiteApi\API\FilterService;
-use Netgen\EzPlatformSiteApi\API\FindService;
-use Netgen\EzPlatformSiteApi\API\LoadService;
+use Netgen\EzPlatformSiteApi\API\FilterService as FilterServiceInterface;
+use Netgen\EzPlatformSiteApi\API\FindService as FindServiceInterface;
+use Netgen\EzPlatformSiteApi\API\LoadService as LoadServiceInterface;
 use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
 
 class Site implements SiteInterface
@@ -30,9 +30,9 @@ class Site implements SiteInterface
      * @param \Netgen\EzPlatformSiteApi\API\LoadService $loadService
      */
     public function __construct(
-        FilterService $filterService,
-        FindService $findService,
-        LoadService $loadService
+        FilterServiceInterface $filterService,
+        FindServiceInterface $findService,
+        LoadServiceInterface $loadService
     ) {
         $this->filterService = $filterService;
         $this->findService = $findService;

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -185,7 +185,7 @@ final class Content extends APIContent
         $cacheId = $limit;
 
         if (!array_key_exists($cacheId, $this->locationsCache)) {
-            $searchResult = $this->site->getFindService()->findLocations(
+            $searchResult = $this->site->getFilterService()->filterLocations(
                 new LocationQuery(
                     [
                         'filter' => new LogicalAnd(

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -136,7 +136,7 @@ final class ContentInfo extends APIContentInfo
         $cacheId = $limit;
 
         if (!array_key_exists($cacheId, $this->locationsCache)) {
-            $searchResult = $this->site->getFindService()->findLocations(
+            $searchResult = $this->site->getFilterService()->filterLocations(
                 new LocationQuery(
                     [
                         'filter' => new LogicalAnd(

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -133,7 +133,7 @@ final class Location extends APILocation
                 $criteria[] = new ContentTypeIdentifier($contentTypeIdentifiers);
             }
 
-            $searchResult = $this->site->getFindService()->findLocations(
+            $searchResult = $this->site->getFilterService()->filterLocations(
                 new LocationQuery(
                     [
                         'filter' => new LogicalAnd($criteria),
@@ -165,7 +165,7 @@ final class Location extends APILocation
                 $criteria[] = new ContentTypeIdentifier($contentTypeIdentifiers);
             }
 
-            $searchResult = $this->site->getFindService()->findLocations(
+            $searchResult = $this->site->getFilterService()->filterLocations(
                 new LocationQuery(
                     [
                         'filter' => new LogicalAnd($criteria),

--- a/lib/Core/Site/Values/Node.php
+++ b/lib/Core/Site/Values/Node.php
@@ -128,7 +128,7 @@ final class Node extends APINode
                 $criteria[] = new ContentTypeIdentifier($contentTypeIdentifiers);
             }
 
-            $searchResult = $this->site->getFindService()->findLocations(
+            $searchResult = $this->site->getFilterService()->filterLocations(
                 new LocationQuery(
                     [
                         'filter' => new LogicalAnd($criteria),
@@ -160,7 +160,7 @@ final class Node extends APINode
                 $criteria[] = new ContentTypeIdentifier($contentTypeIdentifiers);
             }
 
-            $searchResult = $this->site->getFindService()->findLocations(
+            $searchResult = $this->site->getFilterService()->filterLocations(
                 new LocationQuery(
                     [
                         'filter' => new LogicalAnd($criteria),

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -12,6 +12,16 @@ services:
         calls:
             - [setContainer, ['@service_container']]
 
+    netgen.ezplatform_site.core.filter_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\FilterService
+        lazy: true
+        arguments:
+            - '@netgen.ezplatform_site.core.domain_object_mapper'
+            - '@netgen.ezplatform_site.repository.filter_service'
+            - '@ezpublish.api.service.content'
+            - '%netgen.ezplatform_site.prioritized_languages%'
+            - '%netgen.ezplatform_site.use_always_available%'
+
     netgen.ezplatform_site.core.find_service:
         class: Netgen\EzPlatformSiteApi\Core\Site\FindService
         lazy: true
@@ -36,5 +46,24 @@ services:
         class: Netgen\EzPlatformSiteApi\Core\Site\Site
         lazy: true
         arguments:
+            - '@netgen.ezplatform_site.filter_service'
             - '@netgen.ezplatform_site.find_service'
             - '@netgen.ezplatform_site.load_service'
+
+    netgen.ezplatform_site.inner_repository:
+        class: '%ezpublish.api.inner_repository.class%'
+        factory:
+            - '@ezpublish.api.repository.factory'
+            - buildRepository
+        arguments:
+            - '@ezpublish.api.persistence_handler'
+            - '@ezpublish.spi.search.legacy'
+        lazy: true
+        public: false
+
+    netgen.ezplatform_site.repository.filter_service:
+        class: %ezpublish.api.service.search.class%
+        factory:
+            - '@netgen.ezplatform_site.inner_repository'
+            - getSearchService
+        lazy: true

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -67,3 +67,4 @@ services:
             - '@netgen.ezplatform_site.inner_repository'
             - getSearchService
         lazy: true
+        public: false

--- a/lib/Resources/config/services.yml
+++ b/lib/Resources/config/services.yml
@@ -4,6 +4,9 @@ imports:
 parameters:
 
 services:
+    netgen.ezplatform_site.filter_service:
+        alias: 'netgen.ezplatform_site.core.filter_service'
+
     netgen.ezplatform_site.find_service:
         alias: 'netgen.ezplatform_site.core.find_service'
 


### PR DESCRIPTION
This introduces `FilterService`, which is mostly the same as `FindService`, only it uses Legacy Search Engine, which means it's synchronous, that is data does not need to be indexed in order to be available in search.

Lazy loaded properties and methods are changed to use `FilterService` instead of `FindService`.

Note that fulltext search with `FilterService` will not work, because Legacy Search Engine slots will not be activated here (of course -- unless you also configure `legacy` search engine with Repository). The main idea behind this is to make synchronous search possible when using Solr Search Engine.

Also note that fetching `Node` objects is not possible through `FilterService`, since `Node` was previously deprecated.