### PR TITLE
Introduce pagination

### DIFF
--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -17,7 +17,6 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\ContentInfo $contentInfo
  * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Field[] $fields
- * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location[] $locations Up to 25 Content Locations
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location|null $mainLocation
  * @property-read \eZ\Publish\API\Repository\Values\Content\Content $innerContent
  */
@@ -76,6 +75,15 @@ abstract class Content extends ValueObject
      * @return null|\eZ\Publish\SPI\FieldType\Value
      */
     abstract public function getFieldValueById($id);
+
+    /**
+     * Return an array of Locations, limited by optional $limit.
+     *
+     * @param int $limit
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     */
+    abstract public function getLocations($limit = 25);
 
     /**
      * Return an array of Locations, limited by optional $maxPerPage and $currentPage.

--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -78,11 +78,12 @@ abstract class Content extends ValueObject
     abstract public function getFieldValueById($id);
 
     /**
-     * Return an array of Locations, limited by optional $limit.
+     * Return an array of Locations, limited by optional $maxPerPage and $currentPage.
      *
-     * @param int $limit
+     * @param int $maxPerPage
+     * @param int $currentPage
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
      */
-    abstract public function getLocations($limit = 25);
+    abstract public function filterLocations($maxPerPage = 25, $currentPage = 1);
 }

--- a/lib/API/Values/ContentInfo.php
+++ b/lib/API/Values/ContentInfo.php
@@ -29,12 +29,20 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read string $contentTypeDescription
  * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $innerContentInfo
  * @property-read \eZ\Publish\API\Repository\Values\ContentType\ContentType $innerContentType
- * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location[] $locations Up to 25 Content Locations
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location|null $mainLocation
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Content $content
  */
 abstract class ContentInfo extends ValueObject
 {
+    /**
+     * Return an array of Locations, limited by optional $limit.
+     *
+     * @param int $limit
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     */
+    abstract public function getLocations($limit = 25);
+
     /**
      * Return an array of Locations, limited by optional $maxPerPage and $currentPage.
      *

--- a/lib/API/Values/ContentInfo.php
+++ b/lib/API/Values/ContentInfo.php
@@ -36,11 +36,12 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 abstract class ContentInfo extends ValueObject
 {
     /**
-     * Return an array of Locations, limited by optional $limit.
+     * Return an array of Locations, limited by optional $maxPerPage and $currentPage.
      *
-     * @param int $limit
+     * @param int $maxPerPage
+     * @param int $currentPage
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
      */
-    abstract public function getLocations($limit = 25);
+    abstract public function filterLocations($maxPerPage = 25, $currentPage = 1);
 }

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -25,13 +25,20 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read int|string $contentId
  * @property-read \eZ\Publish\API\Repository\Values\Content\Location $innerLocation
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\ContentInfo $contentInfo
- * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location[] $children Up to 25 child Locations
- * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location[] $siblings Up to 25 sibling Locations
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location|null $parent
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Content $content
  */
 abstract class Location extends ValueObject
 {
+    /**
+     * Return an array of children Locations, limited by optional $limit.
+     *
+     * @param int $limit
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     */
+    abstract public function getChildren($limit = 25);
+
     /**
      * Return an array of children Locations, filtered by optional
      * $contentTypeIdentifiers, $maxPerPage and $currentPage.
@@ -43,6 +50,15 @@ abstract class Location extends ValueObject
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
      */
     abstract public function filterChildren(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1);
+
+    /**
+     * Return an array of Location siblings, limited by optional $limit.
+     *
+     * @param int $limit
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     */
+    abstract public function getSiblings($limit = 25);
 
     /**
      * Return an array of Location siblings, filtered by optional

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -34,7 +34,7 @@ abstract class Location extends ValueObject
 {
     /**
      * Return an array of children Locations, filtered by optional
-     * $limit and $contentTypeIdentifiers.
+     * $contentTypeIdentifiers, $maxPerPage and $currentPage.
      *
      * @param array $contentTypeIdentifiers
      * @param int $maxPerPage
@@ -46,14 +46,15 @@ abstract class Location extends ValueObject
 
     /**
      * Return an array of Location siblings, filtered by optional
-     * $limit and $contentTypeIdentifiers.
+     * $contentTypeIdentifiers, $maxPerPage and $currentPage.
      *
      * Siblings will not include current Locations.
      *
-     * @param int $limit
      * @param array $contentTypeIdentifiers
+     * @param int $maxPerPage
+     * @param int $currentPage
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
      */
-    abstract public function getSiblings($limit = 25, array $contentTypeIdentifiers = []);
+    abstract public function filterSiblings(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1);
 }

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -36,12 +36,13 @@ abstract class Location extends ValueObject
      * Return an array of children Locations, filtered by optional
      * $limit and $contentTypeIdentifiers.
      *
-     * @param int $limit
      * @param array $contentTypeIdentifiers
+     * @param int $maxPerPage
+     * @param int $currentPage
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
      */
-    abstract public function getChildren($limit = 25, array $contentTypeIdentifiers = []);
+    abstract public function filterChildren(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1);
 
     /**
      * Return an array of Location siblings, filtered by optional

--- a/lib/Core/Site/Pagination/Pagerfanta/LocationSearchFilterAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/LocationSearchFilterAdapter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
+
+use Netgen\EzPlatformSiteApi\API\FilterService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use Pagerfanta\Adapter\AdapterInterface;
+
+/**
+ * Pagerfanta adapter for Netgen eZ Platform Site Location filtering.
+ * Will return results as Site Location objects.
+ */
+class LocationSearchFilterAdapter implements AdapterInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\LocationQuery
+     */
+    private $query;
+
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FilterService
+     */
+    private $filterService;
+
+    /**
+     * @var int
+     */
+    private $nbResults;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param \Netgen\EzPlatformSiteApi\API\FilterService $filterService
+     */
+    public function __construct(LocationQuery $query, FilterService $filterService)
+    {
+        $this->query = $query;
+        $this->filterService = $filterService;
+    }
+
+    public function getNbResults()
+    {
+        if (null !== $this->nbResults) {
+            return $this->nbResults;
+        }
+
+        $countQuery = clone $this->query;
+        $countQuery->limit = 0;
+
+        return $this->nbResults = $this->filterService->filterLocations($countQuery)->totalCount;
+    }
+
+    /**
+     * Returns a slice of the results, as Site Location objects.
+     *
+     * @param int $offset The offset
+     * @param int $length The length
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     */
+    public function getSlice($offset, $length)
+    {
+        $query = clone $this->query;
+        $query->offset = $offset;
+        $query->limit = $length;
+        $query->performCount = false;
+
+        $searchResult = $this->filterService->filterLocations($query);
+
+        // Set count for further use if returned by search engine despite !performCount (Solr, ES)
+        if (null === $this->nbResults && null !== $searchResult->totalCount) {
+            $this->nbResults = $searchResult->totalCount;
+        }
+
+        $list = [];
+        foreach ($searchResult->searchHits as $hit) {
+            $list[] = $hit->valueObject;
+        }
+
+        return $list;
+    }
+}

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -130,8 +130,6 @@ final class Content extends APIContent
                 return $this->contentInfo->name;
             case 'mainLocationId':
                 return $this->contentInfo->mainLocationId;
-            case 'locations':
-                return $this->getLocations();
             case 'mainLocation':
                 return $this->getMainLocation();
         }
@@ -160,7 +158,6 @@ final class Content extends APIContent
             case 'id':
             case 'name':
             case 'mainLocationId':
-            case 'locations':
             case 'mainLocation':
                 return true;
         }
@@ -179,6 +176,11 @@ final class Content extends APIContent
 
         $this->fields[$field->fieldDefIdentifier] = $field;
         $this->fieldsById[$field->id] = $field;
+    }
+
+    public function getLocations($limit = 25)
+    {
+        return $this->filterLocations($limit)->getIterator();
     }
 
     public function filterLocations($maxPerPage = 25, $currentPage = 1)

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -87,8 +87,6 @@ final class ContentInfo extends APIContentInfo
                     $this->languageCode,
                     (array)$this->innerContentType->getDescriptions()
                 );
-            case 'locations':
-                return $this->filterLocations();
             case 'mainLocation':
                 return $this->getMainLocation();
             case 'content':
@@ -119,7 +117,6 @@ final class ContentInfo extends APIContentInfo
             case 'contentTypeIdentifier':
             case 'contentTypeName':
             case 'contentTypeDescription':
-            case 'locations':
             case 'mainLocation':
             case 'content':
                 return true;
@@ -130,6 +127,11 @@ final class ContentInfo extends APIContentInfo
         }
 
         return parent::__isset($property);
+    }
+
+    public function getLocations($limit = 25)
+    {
+        return $this->filterLocations($limit)->getIterator();
     }
 
     public function filterLocations($maxPerPage = 25, $currentPage = 1)

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -74,10 +74,6 @@ final class Location extends APILocation
         switch ($property) {
             case 'contentId':
                 return $this->contentInfo->id;
-            case 'children':
-                return $this->filterChildren()->getIterator();
-            case 'siblings':
-                return $this->filterSiblings()->getIterator();
             case 'parent':
                 return $this->getParent();
             case 'content':
@@ -106,8 +102,6 @@ final class Location extends APILocation
     {
         switch ($property) {
             case 'contentId':
-            case 'children':
-            case 'siblings':
             case 'parent':
             case 'content':
                 return true;
@@ -118,6 +112,11 @@ final class Location extends APILocation
         }
 
         return parent::__isset($property);
+    }
+
+    public function getChildren($limit = 25)
+    {
+        return $this->filterChildren([], $limit)->getIterator();
     }
 
     public function filterChildren(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1)
@@ -153,6 +152,11 @@ final class Location extends APILocation
         $this->childrenPagerCache[$cacheId]->setCurrentPage($currentPage);
 
         return $this->childrenPagerCache[$cacheId];
+    }
+
+    public function getSiblings($limit = 25)
+    {
+        return $this->filterSiblings([], $limit)->getIterator();
     }
 
     public function filterSiblings(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1)

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -197,15 +197,15 @@ final class Location extends APILocation
      * Returns unique string for the given parameters.
      *
      * @param array $contentTypeIdentifiers
-     * @param int $limit
+     * @param int $maxPerPage
      *
      * @return string
      */
-    private function getCacheId(array $contentTypeIdentifiers, $limit)
+    private function getCacheId(array $contentTypeIdentifiers, $maxPerPage)
     {
         sort($contentTypeIdentifiers);
 
-        return md5(implode(' ', $contentTypeIdentifiers) . ' ' . $limit);
+        return md5(implode(' ', $contentTypeIdentifiers) . ' ' . $maxPerPage);
     }
 
     private function getParent()

--- a/lib/Core/Site/Values/Node.php
+++ b/lib/Core/Site/Values/Node.php
@@ -192,15 +192,15 @@ final class Node extends APINode
      * Returns unique string for the given parameters.
      *
      * @param array $contentTypeIdentifiers
-     * @param int $limit
+     * @param int $maxPerPage
      *
      * @return string
      */
-    private function getCacheId(array $contentTypeIdentifiers, $limit)
+    private function getCacheId(array $contentTypeIdentifiers, $maxPerPage)
     {
         sort($contentTypeIdentifiers);
 
-        return md5(implode(' ', $contentTypeIdentifiers) . ' ' . $limit);
+        return md5(implode(' ', $contentTypeIdentifiers) . ' ' . $maxPerPage);
     }
 
     private function getParent()

--- a/lib/Core/Site/Values/Node.php
+++ b/lib/Core/Site/Values/Node.php
@@ -15,8 +15,6 @@ use Pagerfanta\Pagerfanta;
 
 final class Node extends APINode
 {
-    use ValueObjectExtractorTrait;
-
     /**
      * @var \Netgen\EzPlatformSiteApi\API\Values\Content
      */

--- a/lib/Core/Site/Values/Node.php
+++ b/lib/Core/Site/Values/Node.php
@@ -72,10 +72,6 @@ final class Node extends APINode
         switch ($property) {
             case 'contentId':
                 return $this->contentInfo->id;
-            case 'children':
-                return $this->filterChildren();
-            case 'siblings':
-                return $this->filterSiblings();
             case 'parent':
                 return $this->getParent();
         }
@@ -102,8 +98,6 @@ final class Node extends APINode
     {
         switch ($property) {
             case 'contentId':
-            case 'children':
-            case 'siblings':
             case 'parent':
                 return true;
         }
@@ -113,6 +107,11 @@ final class Node extends APINode
         }
 
         return parent::__isset($property);
+    }
+
+    public function getChildren($limit = 25)
+    {
+        return $this->filterChildren([], $limit)->getIterator();
     }
 
     public function filterChildren(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1)
@@ -148,6 +147,11 @@ final class Node extends APINode
         $this->childrenPagerCache[$cacheId]->setCurrentPage($currentPage);
 
         return $this->childrenPagerCache[$cacheId];
+    }
+
+    public function getSiblings($limit = 25)
+    {
+        return $this->filterSiblings([], $limit)->getIterator();
     }
 
     public function filterSiblings(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1)

--- a/lib/Core/Site/Values/ValueObjectExtractorTrait.php
+++ b/lib/Core/Site/Values/ValueObjectExtractorTrait.php
@@ -4,6 +4,9 @@ namespace Netgen\EzPlatformSiteApi\Core\Site\Values;
 
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 
+/**
+ * @internal
+ */
 trait ValueObjectExtractorTrait
 {
     /**


### PR DESCRIPTION
This introduces possibility of pagination, for now only on Location children.

`getChildren($limit = 25, array $contentTypeIdentifiers = [])` method was renamed and signature was changed to `filterChildren(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1)`. The method now returns `Pagerfanta` instance.

Note that we don't have offset as initially discussed, as it would have to be converted to current page anyway. Comments welcome on that part.

When `children` property is accessed, internal iterator is returned instead of `Pagerfanta` instance.

This enables following:

```twig
{% set children = location.parent.filterChildren %}
<p>Total count: {{ children.nbResults }}</p>
<p>Page: {{ children.currentPage }}</p>
<p>Max per page: {{ children.maxPerPage }}</p>
<ul>
{% for child in children %}
    <li>{{ child.contentInfo.name }}</li>
{% endfor %}
</ul>
{{ pagerfanta( children, 'twitter_bootstrap' ) }}
```

Note the introduction of `LocationSearchFilterAdapter` adapter for `Pagerfanta`, using `FilterService`.

### To-dos
- [x] expand this on the rest of the methods (locations, siblings)
- [x] ~~introduce `PagerBuilderTrait` to ease using pagination~~ left for some future PR