### PR TITLE
Refactor service building

### DIFF
--- a/bundle/Core/Site/Settings.php
+++ b/bundle/Core/Site/Settings.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Core\Site;
+
+use eZ\Publish\API\Repository\Exceptions\PropertyNotFoundException;
+use eZ\Publish\API\Repository\Exceptions\PropertyReadOnlyException;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Netgen\EzPlatformSiteApi\API\Settings as BaseSettings;
+
+final class Settings extends BaseSettings
+{
+    /**
+     * @var bool
+     */
+    private $useAlwaysAvailable;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver
+     */
+    private $configResolver;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     * @param bool $useAlwaysAvailable
+     */
+    public function __construct(ConfigResolverInterface $configResolver, $useAlwaysAvailable)
+    {
+        $this->configResolver = $configResolver;
+        $this->useAlwaysAvailable = $useAlwaysAvailable;
+    }
+
+    public function __get($property)
+    {
+        switch ($property) {
+            case 'prioritizedLanguages':
+                return $this->configResolver->getParameter('languages');
+            case 'useAlwaysAvailable':
+                return $this->useAlwaysAvailable;
+            case 'rootLocationId':
+                return $this->configResolver->getParameter('content.tree_root.location_id');
+        }
+
+        throw new PropertyNotFoundException($property, get_class($this));
+    }
+
+    public function __set($property, $value)
+    {
+        throw new PropertyReadOnlyException($property, get_class($this));
+    }
+
+    public function __isset($property)
+    {
+        switch ($property) {
+            case 'prioritizedLanguages':
+            case 'useAlwaysAvailable':
+            case 'rootLocationId':
+                return true;
+        }
+
+        throw new PropertyNotFoundException($property, get_class($this));
+    }
+}

--- a/bundle/Core/Site/Settings.php
+++ b/bundle/Core/Site/Settings.php
@@ -10,23 +10,16 @@ use Netgen\EzPlatformSiteApi\API\Settings as BaseSettings;
 final class Settings extends BaseSettings
 {
     /**
-     * @var bool
-     */
-    private $useAlwaysAvailable;
-
-    /**
      * @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver
      */
     private $configResolver;
 
     /**
      * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
-     * @param bool $useAlwaysAvailable
      */
-    public function __construct(ConfigResolverInterface $configResolver, $useAlwaysAvailable)
+    public function __construct(ConfigResolverInterface $configResolver)
     {
         $this->configResolver = $configResolver;
-        $this->useAlwaysAvailable = $useAlwaysAvailable;
     }
 
     public function __get($property)
@@ -35,7 +28,10 @@ final class Settings extends BaseSettings
             case 'prioritizedLanguages':
                 return $this->configResolver->getParameter('languages');
             case 'useAlwaysAvailable':
-                return $this->useAlwaysAvailable;
+                return $this->configResolver->getParameter(
+                    'use_always_available_fallback',
+                    'netgen_ez_platform_site_api'
+                );
             case 'rootLocationId':
                 return $this->configResolver->getParameter('content.tree_root.location_id');
         }

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -29,7 +29,13 @@ class Configuration extends SiteAccessConfiguration
         $systemNode = $this->generateScopeBaseNode($rootNode);
         $systemNode
             ->booleanNode('override_url_alias_view_action')
-                ->info('Whether to override URL alias view action')
+                ->info('Controls override of the URL alias view action')
+                ->defaultFalse()
+            ->end();
+        $systemNode
+            ->booleanNode('use_always_available_fallback')
+                ->info('Controls fallback to main language marked as always available')
+                ->defaultTrue()
             ->end();
     }
 }

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -30,12 +30,10 @@ class Configuration extends SiteAccessConfiguration
         $systemNode
             ->booleanNode('override_url_alias_view_action')
                 ->info('Controls override of the URL alias view action')
-                ->defaultFalse()
             ->end();
         $systemNode
             ->booleanNode('use_always_available_fallback')
                 ->info('Controls fallback to main language marked as always available')
-                ->defaultTrue()
             ->end();
     }
 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -22,7 +22,6 @@ services:
 
     netgen.ezplatform_site.core.site:
         class: Netgen\EzPlatformSiteApi\Core\Site\Site
-        lazy: true
         arguments:
             - '@ezpublish.api.service.content'
             - '@ezpublish.api.service.content_type'
@@ -33,6 +32,34 @@ services:
             - '%netgen.ezplatform_site.use_always_available%'
         calls:
             - [setPrioritizedLanguages, ['$languages$']]
+        lazy: true
+
+    netgen.ezplatform_site.core.filter_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\FilterService
+        factory:
+            - '@netgen.ezplatform_site.core.site'
+            - getFilterService
+        calls:
+            - [setPrioritizedLanguages, ['$languages$']]
+        lazy: true
+
+    netgen.ezplatform_site.core.find_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\FindService
+        factory:
+            - '@netgen.ezplatform_site.core.site'
+            - getFindService
+        calls:
+            - [setPrioritizedLanguages, ['$languages$']]
+        lazy: true
+
+    netgen.ezplatform_site.core.load_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\LoadService
+        factory:
+            - '@netgen.ezplatform_site.core.site'
+            - getLoadService
+        calls:
+            - [setPrioritizedLanguages, ['$languages$']]
+        lazy: true
 
     netgen.ezplatform_site.controller.content.view:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Controller\Content\ViewController

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -12,6 +12,7 @@ parameters:
 
     # Defaults for semantic configuration
     netgen_ez_platform_site_api.default.override_url_alias_view_action: false
+    netgen_ez_platform_site_api.default.use_always_available_fallback: true
 
 services:
     netgen.ezplatform_site.controller.base:

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -18,37 +18,21 @@ services:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Controller\Controller
         abstract: true
         calls:
-            - [setContainer, ["@service_container"]]
+            - [setContainer, ['@service_container']]
 
-    netgen.ezplatform_site.core.filter_service:
-        class: Netgen\EzPlatformSiteApi\Core\Site\FilterService
+    netgen.ezplatform_site.core.site:
+        class: Netgen\EzPlatformSiteApi\Core\Site\Site
         lazy: true
         arguments:
-            - '@netgen.ezplatform_site.core.domain_object_mapper'
-            - '@netgen.ezplatform_site.repository.filter_service'
             - '@ezpublish.api.service.content'
-            - '$languages$'
-            - '%netgen.ezplatform_site.use_always_available%'
-
-    netgen.ezplatform_site.core.find_service:
-        class: Netgen\EzPlatformSiteApi\Core\Site\FindService
-        lazy: true
-        arguments:
-            - '@netgen.ezplatform_site.core.domain_object_mapper'
-            - '@ezpublish.api.service.search'
-            - '@ezpublish.api.service.content'
-            - '$languages$'
-            - '%netgen.ezplatform_site.use_always_available%'
-
-    netgen.ezplatform_site.core.load_service:
-        class: Netgen\EzPlatformSiteApi\Core\Site\LoadService
-        lazy: true
-        arguments:
-            - '@netgen.ezplatform_site.core.domain_object_mapper'
-            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.content_type'
+            - '@ezpublish.api.service.field_type'
             - '@ezpublish.api.service.location'
-            - '$languages$'
+            - '@ezpublish.api.service.search'
+            - '@netgen.ezplatform_site.repository.filter_service'
             - '%netgen.ezplatform_site.use_always_available%'
+        calls:
+            - [setPrioritizedLanguages, ['$languages$']]
 
     netgen.ezplatform_site.controller.content.view:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Controller\Content\ViewController

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -20,18 +20,22 @@ services:
         calls:
             - [setContainer, ['@service_container']]
 
+    netgen.ezplatform_site.core.settings:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Core\Site\Settings
+        arguments:
+            - '@ezpublish.config.resolver'
+            - '%netgen.ezplatform_site.use_always_available%'
+
     netgen.ezplatform_site.core.site:
         class: Netgen\EzPlatformSiteApi\Core\Site\Site
         arguments:
+            - '@netgen.ezplatform_site.settings'
             - '@ezpublish.api.service.content'
             - '@ezpublish.api.service.content_type'
             - '@ezpublish.api.service.field_type'
             - '@ezpublish.api.service.location'
             - '@ezpublish.api.service.search'
-            - '@netgen.ezplatform_site.repository.filter_service'
-            - '%netgen.ezplatform_site.use_always_available%'
-        calls:
-            - [setPrioritizedLanguages, ['$languages$']]
+            - '@netgen.ezplatform_site.repository.filtering_search_service'
         lazy: true
 
     netgen.ezplatform_site.core.filter_service:
@@ -39,8 +43,6 @@ services:
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getFilterService
-        calls:
-            - [setPrioritizedLanguages, ['$languages$']]
         lazy: true
 
     netgen.ezplatform_site.core.find_service:
@@ -48,8 +50,6 @@ services:
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getFindService
-        calls:
-            - [setPrioritizedLanguages, ['$languages$']]
         lazy: true
 
     netgen.ezplatform_site.core.load_service:
@@ -57,8 +57,6 @@ services:
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getLoadService
-        calls:
-            - [setPrioritizedLanguages, ['$languages$']]
         lazy: true
 
     netgen.ezplatform_site.controller.content.view:
@@ -80,4 +78,4 @@ services:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageExtension
         arguments: ['@ezpublish.fieldType.ezimage.variation_service']
         tags:
-            - { name: twig.extension }
+            - {name: twig.extension}

--- a/lib/API/Settings.php
+++ b/lib/API/Settings.php
@@ -3,11 +3,11 @@
 namespace Netgen\EzPlatformSiteApi\API;
 
 /**
- * Base Settings class.
+ * Site Settings.
  *
- * @property-read array $prioritizedLanguages
- * @property-read bool $useAlwaysAvailable
- * @property-read int|string $rootLocationId
+ * @property-read array $prioritizedLanguages Array of prioritized languages
+ * @property-read bool $useAlwaysAvailable Always available fallback state
+ * @property-read int|string $rootLocationId Root Location ID
  */
 abstract class Settings
 {

--- a/lib/API/Settings.php
+++ b/lib/API/Settings.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\API;
+
+/**
+ * Base Settings class.
+ *
+ * @property-read array $prioritizedLanguages
+ * @property-read bool $useAlwaysAvailable
+ * @property-read int|string $rootLocationId
+ */
+abstract class Settings
+{
+}

--- a/lib/API/Site.php
+++ b/lib/API/Site.php
@@ -8,6 +8,13 @@ namespace Netgen\EzPlatformSiteApi\API;
 interface Site
 {
     /**
+     * Settings getter.
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Settings
+     */
+    public function getSettings();
+
+    /**
      * FilterService getter.
      *
      * @return \Netgen\EzPlatformSiteApi\API\FilterService

--- a/lib/Core/Site/DomainObjectMapper.php
+++ b/lib/Core/Site/DomainObjectMapper.php
@@ -2,6 +2,7 @@
 
 namespace Netgen\EzPlatformSiteApi\Core\Site;
 
+use Netgen\EzPlatformSiteApi\API\Site;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\Content;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\ContentInfo;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\Location;
@@ -13,7 +14,6 @@ use eZ\Publish\API\Repository\Values\Content\Field as APIField;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @internal
@@ -23,7 +23,10 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  */
 final class DomainObjectMapper
 {
-    use ContainerAwareTrait;
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\Site
+     */
+    private $site;
 
     /**
      * @var \eZ\Publish\API\Repository\FieldTypeService
@@ -36,13 +39,16 @@ final class DomainObjectMapper
     private $contentTypeService;
 
     /**
+     * @param \Netgen\EzPlatformSiteApi\API\Site $site
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \eZ\Publish\API\Repository\FieldTypeService $fieldTypeService
      */
     public function __construct(
+        Site $site,
         ContentTypeService $contentTypeService,
         FieldTypeService $fieldTypeService
     ) {
+        $this->site = $site;
         $this->contentTypeService = $contentTypeService;
         $this->fieldTypeService = $fieldTypeService;
     }
@@ -75,7 +81,7 @@ final class DomainObjectMapper
                     $contentType
                 ),
                 'innerContent' => $content,
-                'site' => $this->container->get('netgen.ezplatform_site.core.site'),
+                'site' => $this->site,
             ]
         );
     }
@@ -106,7 +112,7 @@ final class DomainObjectMapper
                 'languageCode' => $languageCode,
                 'innerContentInfo' => $versionInfo->contentInfo,
                 'innerContentType' => $contentType,
-                'site' => $this->container->get('netgen.ezplatform_site.core.site'),
+                'site' => $this->site,
             ]
         );
     }
@@ -126,7 +132,7 @@ final class DomainObjectMapper
             [
                 'contentInfo' => $this->mapContentInfo($versionInfo, $languageCode),
                 'innerLocation' => $location,
-                'site' => $this->container->get('netgen.ezplatform_site.core.site'),
+                'site' => $this->site,
             ]
         );
     }
@@ -147,7 +153,7 @@ final class DomainObjectMapper
                 'contentInfo' => $this->mapContentInfo($content->versionInfo, $languageCode),
                 'innerLocation' => $location,
                 'content' => $this->mapContent($content, $languageCode),
-                'site' => $this->container->get('netgen.ezplatform_site.core.site'),
+                'site' => $this->site,
             ]
         );
     }

--- a/lib/Core/Site/DomainObjectMapper.php
+++ b/lib/Core/Site/DomainObjectMapper.php
@@ -2,7 +2,7 @@
 
 namespace Netgen\EzPlatformSiteApi\Core\Site;
 
-use Netgen\EzPlatformSiteApi\API\Site;
+use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\Content;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\ContentInfo;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\Location;
@@ -44,7 +44,7 @@ final class DomainObjectMapper
      * @param \eZ\Publish\API\Repository\FieldTypeService $fieldTypeService
      */
     public function __construct(
-        Site $site,
+        SiteInterface $site,
         ContentTypeService $contentTypeService,
         FieldTypeService $fieldTypeService
     ) {

--- a/lib/Core/Site/FilterService.php
+++ b/lib/Core/Site/FilterService.php
@@ -3,6 +3,7 @@
 namespace Netgen\EzPlatformSiteApi\Core\Site;
 
 use Netgen\EzPlatformSiteApi\API\FilterService as FilterServiceInterface;
+use Netgen\EzPlatformSiteApi\API\Settings as BaseSettings;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
@@ -10,6 +11,11 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 
 class FilterService implements FilterServiceInterface
 {
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\Settings
+     */
+    private $settings;
+
     /**
      * @var \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper
      */
@@ -26,42 +32,21 @@ class FilterService implements FilterServiceInterface
     private $contentService;
 
     /**
-     * @var array
-     */
-    private $prioritizedLanguages;
-
-    /**
-     * @var bool
-     */
-    private $useAlwaysAvailable;
-
-    /**
+     * @param \Netgen\EzPlatformSiteApi\API\Settings $settings
      * @param \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper $domainObjectMapper
      * @param \eZ\Publish\API\Repository\SearchService $searchService
      * @param \eZ\Publish\API\Repository\ContentService $contentService
-     * @param bool $useAlwaysAvailable
      */
     public function __construct(
+        BaseSettings $settings,
         DomainObjectMapper $domainObjectMapper,
         SearchService $searchService,
-        ContentService $contentService,
-        $useAlwaysAvailable
+        ContentService $contentService
     ) {
+        $this->settings = $settings;
         $this->domainObjectMapper = $domainObjectMapper;
         $this->searchService = $searchService;
         $this->contentService = $contentService;
-        $this->useAlwaysAvailable = $useAlwaysAvailable;
-    }
-
-    /**
-     * Setter for prioritized languages configuration, used to update
-     * the configuration on scope change.
-     *
-     * @param array $prioritizedLanguages
-     */
-    public function setPrioritizedLanguages(array $prioritizedLanguages = null)
-    {
-        $this->prioritizedLanguages = $prioritizedLanguages;
     }
 
     public function filterContent(Query $query)
@@ -69,8 +54,8 @@ class FilterService implements FilterServiceInterface
         $searchResult = $this->searchService->findContentInfo(
             $query,
             [
-                'languages' => $this->prioritizedLanguages,
-                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+                'languages' => $this->settings->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->settings->useAlwaysAvailable,
             ]
         );
 
@@ -94,8 +79,8 @@ class FilterService implements FilterServiceInterface
         $searchResult = $this->searchService->findContentInfo(
             $query,
             [
-                'languages' => $this->prioritizedLanguages,
-                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+                'languages' => $this->settings->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->settings->useAlwaysAvailable,
             ]
         );
 
@@ -119,8 +104,8 @@ class FilterService implements FilterServiceInterface
         $searchResult = $this->searchService->findLocations(
             $query,
             [
-                'languages' => $this->prioritizedLanguages,
-                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+                'languages' => $this->settings->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->settings->useAlwaysAvailable,
             ]
         );
 

--- a/lib/Core/Site/FilterService.php
+++ b/lib/Core/Site/FilterService.php
@@ -39,21 +39,29 @@ class FilterService implements FilterServiceInterface
      * @param \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper $domainObjectMapper
      * @param \eZ\Publish\API\Repository\SearchService $searchService
      * @param \eZ\Publish\API\Repository\ContentService $contentService
-     * @param array $prioritizedLanguages
      * @param bool $useAlwaysAvailable
      */
     public function __construct(
         DomainObjectMapper $domainObjectMapper,
         SearchService $searchService,
         ContentService $contentService,
-        array $prioritizedLanguages,
         $useAlwaysAvailable
     ) {
         $this->domainObjectMapper = $domainObjectMapper;
         $this->searchService = $searchService;
         $this->contentService = $contentService;
-        $this->prioritizedLanguages = $prioritizedLanguages;
         $this->useAlwaysAvailable = $useAlwaysAvailable;
+    }
+
+    /**
+     * Setter for prioritized languages configuration, used to update
+     * the configuration on scope change.
+     *
+     * @param array $prioritizedLanguages
+     */
+    public function setPrioritizedLanguages(array $prioritizedLanguages = null)
+    {
+        $this->prioritizedLanguages = $prioritizedLanguages;
     }
 
     public function filterContent(Query $query)

--- a/lib/Core/Site/FindService.php
+++ b/lib/Core/Site/FindService.php
@@ -3,6 +3,7 @@
 namespace Netgen\EzPlatformSiteApi\Core\Site;
 
 use Netgen\EzPlatformSiteApi\API\FindService as FindServiceInterface;
+use Netgen\EzPlatformSiteApi\API\Settings as BaseSettings;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
@@ -10,6 +11,11 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 
 class FindService implements FindServiceInterface
 {
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\Settings
+     */
+    private $settings;
+
     /**
      * @var \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper
      */
@@ -26,42 +32,21 @@ class FindService implements FindServiceInterface
     private $contentService;
 
     /**
-     * @var array
-     */
-    private $prioritizedLanguages;
-
-    /**
-     * @var bool
-     */
-    private $useAlwaysAvailable;
-
-    /**
+     * @param \Netgen\EzPlatformSiteApi\API\Settings $settings
      * @param \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper $domainObjectMapper
      * @param \eZ\Publish\API\Repository\SearchService $searchService
      * @param \eZ\Publish\API\Repository\ContentService $contentService
-     * @param bool $useAlwaysAvailable
      */
     public function __construct(
+        BaseSettings $settings,
         DomainObjectMapper $domainObjectMapper,
         SearchService $searchService,
-        ContentService $contentService,
-        $useAlwaysAvailable
+        ContentService $contentService
     ) {
+        $this->settings = $settings;
         $this->domainObjectMapper = $domainObjectMapper;
         $this->searchService = $searchService;
         $this->contentService = $contentService;
-        $this->useAlwaysAvailable = $useAlwaysAvailable;
-    }
-
-    /**
-     * Setter for prioritized languages configuration, used to update
-     * the configuration on scope change.
-     *
-     * @param array $prioritizedLanguages
-     */
-    public function setPrioritizedLanguages(array $prioritizedLanguages = null)
-    {
-        $this->prioritizedLanguages = $prioritizedLanguages;
     }
 
     public function findContent(Query $query)
@@ -69,8 +54,8 @@ class FindService implements FindServiceInterface
         $searchResult = $this->searchService->findContentInfo(
             $query,
             [
-                'languages' => $this->prioritizedLanguages,
-                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+                'languages' => $this->settings->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->settings->useAlwaysAvailable,
             ]
         );
 
@@ -94,8 +79,8 @@ class FindService implements FindServiceInterface
         $searchResult = $this->searchService->findContentInfo(
             $query,
             [
-                'languages' => $this->prioritizedLanguages,
-                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+                'languages' => $this->settings->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->settings->useAlwaysAvailable,
             ]
         );
 
@@ -119,8 +104,8 @@ class FindService implements FindServiceInterface
         $searchResult = $this->searchService->findLocations(
             $query,
             [
-                'languages' => $this->prioritizedLanguages,
-                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+                'languages' => $this->settings->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->settings->useAlwaysAvailable,
             ]
         );
 
@@ -145,8 +130,8 @@ class FindService implements FindServiceInterface
         $searchResult = $this->searchService->findLocations(
             $query,
             [
-                'languages' => $this->prioritizedLanguages,
-                'useAlwaysAvailable' => $this->useAlwaysAvailable,
+                'languages' => $this->settings->prioritizedLanguages,
+                'useAlwaysAvailable' => $this->settings->useAlwaysAvailable,
             ]
         );
 

--- a/lib/Core/Site/FindService.php
+++ b/lib/Core/Site/FindService.php
@@ -39,21 +39,29 @@ class FindService implements FindServiceInterface
      * @param \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper $domainObjectMapper
      * @param \eZ\Publish\API\Repository\SearchService $searchService
      * @param \eZ\Publish\API\Repository\ContentService $contentService
-     * @param array $prioritizedLanguages
      * @param bool $useAlwaysAvailable
      */
     public function __construct(
         DomainObjectMapper $domainObjectMapper,
         SearchService $searchService,
         ContentService $contentService,
-        array $prioritizedLanguages,
         $useAlwaysAvailable
     ) {
         $this->domainObjectMapper = $domainObjectMapper;
         $this->searchService = $searchService;
         $this->contentService = $contentService;
-        $this->prioritizedLanguages = $prioritizedLanguages;
         $this->useAlwaysAvailable = $useAlwaysAvailable;
+    }
+
+    /**
+     * Setter for prioritized languages configuration, used to update
+     * the configuration on scope change.
+     *
+     * @param array $prioritizedLanguages
+     */
+    public function setPrioritizedLanguages(array $prioritizedLanguages = null)
+    {
+        $this->prioritizedLanguages = $prioritizedLanguages;
     }
 
     public function findContent(Query $query)

--- a/lib/Core/Site/LoadService.php
+++ b/lib/Core/Site/LoadService.php
@@ -40,21 +40,29 @@ class LoadService implements LoadServiceInterface
      * @param \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper $domainObjectMapper
      * @param \eZ\Publish\API\Repository\ContentService $contentService
      * @param \eZ\Publish\API\Repository\LocationService $locationService
-     * @param string[] $prioritizedLanguages
      * @param bool $useAlwaysAvailable
      */
     public function __construct(
         DomainObjectMapper $domainObjectMapper,
         ContentService $contentService,
         LocationService $locationService,
-        array $prioritizedLanguages,
         $useAlwaysAvailable
     ) {
         $this->domainObjectMapper = $domainObjectMapper;
         $this->contentService = $contentService;
         $this->locationService = $locationService;
-        $this->prioritizedLanguages = $prioritizedLanguages;
         $this->useAlwaysAvailable = $useAlwaysAvailable;
+    }
+
+    /**
+     * Setter for prioritized languages configuration, used to update
+     * the configuration on scope change.
+     *
+     * @param array $prioritizedLanguages
+     */
+    public function setPrioritizedLanguages(array $prioritizedLanguages = null)
+    {
+        $this->prioritizedLanguages = $prioritizedLanguages;
     }
 
     public function loadContent($contentId, $versionNo = null, $languageCode = null)

--- a/lib/Core/Site/Settings.php
+++ b/lib/Core/Site/Settings.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site;
+
+use eZ\Publish\API\Repository\Exceptions\PropertyNotFoundException;
+use eZ\Publish\API\Repository\Exceptions\PropertyReadOnlyException;
+use Netgen\EzPlatformSiteApi\API\Settings as BaseSettings;
+
+final class Settings extends BaseSettings
+{
+    /**
+     * @var string[]
+     */
+    private $prioritizedLanguages;
+
+    /**
+     * @var bool
+     */
+    private $useAlwaysAvailable;
+
+    /**
+     * @var int|string
+     */
+    private $rootLocationId;
+
+    /**
+     * @param string[] $prioritizedLanguages
+     * @param bool $useAlwaysAvailable
+     * @param int|string $rootLocationId
+     */
+    public function __construct($prioritizedLanguages, $useAlwaysAvailable, $rootLocationId)
+    {
+        $this->prioritizedLanguages = $prioritizedLanguages;
+        $this->useAlwaysAvailable = $useAlwaysAvailable;
+        $this->rootLocationId = $rootLocationId;
+    }
+
+    public function __get($property)
+    {
+        switch ($property) {
+            case 'prioritizedLanguages':
+                return $this->prioritizedLanguages;
+            case 'useAlwaysAvailable':
+                return $this->useAlwaysAvailable;
+            case 'rootLocationId':
+                return $this->rootLocationId;
+        }
+
+        throw new PropertyNotFoundException($property, get_class($this));
+    }
+
+    public function __set($property, $value)
+    {
+        throw new PropertyReadOnlyException($property, get_class($this));
+    }
+
+    public function __isset($property)
+    {
+        switch ($property) {
+            case 'prioritizedLanguages':
+            case 'useAlwaysAvailable':
+            case 'rootLocationId':
+                return true;
+        }
+
+        throw new PropertyNotFoundException($property, get_class($this));
+    }
+}

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -104,58 +104,55 @@ class Site implements SiteInterface
      *
      * @param array $prioritizedLanguages
      */
-    public function setPrioritizedLanguages(array $prioritizedLanguages)
+    public function setPrioritizedLanguages(array $prioritizedLanguages = null)
     {
         $this->prioritizedLanguages = $prioritizedLanguages;
     }
 
     public function getFilterService()
     {
-        if ($this->filterService !== null) {
-            return $this->filterService;
+        if ($this->filterService === null) {
+            $this->filterService = new FilterService(
+                $this->getDomainObjectMapper(),
+                $this->synchronousSearchService,
+                $this->contentService,
+                $this->useAlwaysAvailable
+            );
         }
 
-        $this->filterService = new FilterService(
-            $this->getDomainObjectMapper(),
-            $this->synchronousSearchService,
-            $this->contentService,
-            $this->prioritizedLanguages,
-            $this->useAlwaysAvailable
-        );
+        $this->filterService->setPrioritizedLanguages($this->prioritizedLanguages);
 
         return $this->filterService;
     }
 
     public function getFindService()
     {
-        if ($this->findService !== null) {
-            return $this->findService;
+        if ($this->findService === null) {
+            $this->findService = new FindService(
+                $this->getDomainObjectMapper(),
+                $this->searchService,
+                $this->contentService,
+                $this->useAlwaysAvailable
+            );
         }
 
-        $this->findService = new FindService(
-            $this->getDomainObjectMapper(),
-            $this->searchService,
-            $this->contentService,
-            $this->prioritizedLanguages,
-            $this->useAlwaysAvailable
-        );
+        $this->findService->setPrioritizedLanguages($this->prioritizedLanguages);
 
         return $this->findService;
     }
 
     public function getLoadService()
     {
-        if ($this->loadService !== null) {
-            return $this->loadService;
+        if ($this->loadService === null) {
+            $this->loadService = new LoadService(
+                $this->getDomainObjectMapper(),
+                $this->contentService,
+                $this->locationService,
+                $this->useAlwaysAvailable
+            );
         }
 
-        $this->loadService = new LoadService(
-            $this->getDomainObjectMapper(),
-            $this->contentService,
-            $this->locationService,
-            $this->prioritizedLanguages,
-            $this->useAlwaysAvailable
-        );
+        $this->loadService->setPrioritizedLanguages($this->prioritizedLanguages);
 
         return $this->loadService;
     }
@@ -165,15 +162,13 @@ class Site implements SiteInterface
      */
     private function getDomainObjectMapper()
     {
-        if ($this->domainObjectMapper !== null) {
-            return $this->domainObjectMapper;
+        if ($this->domainObjectMapper === null) {
+            $this->domainObjectMapper = new DomainObjectMapper(
+                $this,
+                $this->contentTypeService,
+                $this->fieldTypeService
+            );
         }
-
-        $this->domainObjectMapper = new DomainObjectMapper(
-            $this,
-            $this->contentTypeService,
-            $this->fieldTypeService
-        );
 
         return $this->domainObjectMapper;
     }

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -78,7 +78,6 @@ class Site implements SiteInterface
      * @param \eZ\Publish\API\Repository\LocationService $locationService
      * @param \eZ\Publish\API\Repository\SearchService $searchService
      * @param \eZ\Publish\API\Repository\SearchService $synchronousSearchService
-     * @param string[] $prioritizedLanguages
      * @param bool $useAlwaysAvailable
      */
     public function __construct(

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -2,13 +2,60 @@
 
 namespace Netgen\EzPlatformSiteApi\Core\Site;
 
-use Netgen\EzPlatformSiteApi\API\FilterService as FilterServiceInterface;
-use Netgen\EzPlatformSiteApi\API\FindService as FindServiceInterface;
-use Netgen\EzPlatformSiteApi\API\LoadService as LoadServiceInterface;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\SearchService;
 use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
 
 class Site implements SiteInterface
 {
+    /**
+     * @var \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper
+     */
+    private $domainObjectMapper;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\FieldTypeService
+     */
+    private $fieldTypeService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\LocationService
+     */
+    private $locationService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    private $searchService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    private $synchronousSearchService;
+
+    /**
+     * @var array
+     */
+    private $prioritizedLanguages;
+
+    /**
+     * @var bool
+     */
+    private $useAlwaysAvailable;
+
     /**
      * @var \Netgen\EzPlatformSiteApi\API\FilterService
      */
@@ -25,32 +72,110 @@ class Site implements SiteInterface
     private $loadService;
 
     /**
-     * @param \Netgen\EzPlatformSiteApi\API\FilterService $filterService
-     * @param \Netgen\EzPlatformSiteApi\API\FindService $findService
-     * @param \Netgen\EzPlatformSiteApi\API\LoadService $loadService
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \eZ\Publish\API\Repository\FieldTypeService $fieldTypeService
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     * @param \eZ\Publish\API\Repository\SearchService $searchService
+     * @param \eZ\Publish\API\Repository\SearchService $synchronousSearchService
+     * @param string[] $prioritizedLanguages
+     * @param bool $useAlwaysAvailable
      */
     public function __construct(
-        FilterServiceInterface $filterService,
-        FindServiceInterface $findService,
-        LoadServiceInterface $loadService
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        FieldTypeService $fieldTypeService,
+        LocationService $locationService,
+        SearchService $searchService,
+        SearchService $synchronousSearchService,
+        $useAlwaysAvailable
     ) {
-        $this->filterService = $filterService;
-        $this->findService = $findService;
-        $this->loadService = $loadService;
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->fieldTypeService = $fieldTypeService;
+        $this->locationService = $locationService;
+        $this->searchService = $searchService;
+        $this->synchronousSearchService = $synchronousSearchService;
+        $this->useAlwaysAvailable = $useAlwaysAvailable;
+    }
+
+    /**
+     * Setter for prioritized languages configuration, used to update
+     * the configuration on scope change.
+     *
+     * @param array $prioritizedLanguages
+     */
+    public function setPrioritizedLanguages(array $prioritizedLanguages)
+    {
+        $this->prioritizedLanguages = $prioritizedLanguages;
     }
 
     public function getFilterService()
     {
+        if ($this->filterService !== null) {
+            return $this->filterService;
+        }
+
+        $this->filterService = new FilterService(
+            $this->getDomainObjectMapper(),
+            $this->synchronousSearchService,
+            $this->contentService,
+            $this->prioritizedLanguages,
+            $this->useAlwaysAvailable
+        );
+
         return $this->filterService;
     }
 
     public function getFindService()
     {
+        if ($this->findService !== null) {
+            return $this->findService;
+        }
+
+        $this->findService = new FindService(
+            $this->getDomainObjectMapper(),
+            $this->searchService,
+            $this->contentService,
+            $this->prioritizedLanguages,
+            $this->useAlwaysAvailable
+        );
+
         return $this->findService;
     }
 
     public function getLoadService()
     {
+        if ($this->loadService !== null) {
+            return $this->loadService;
+        }
+
+        $this->loadService = new LoadService(
+            $this->getDomainObjectMapper(),
+            $this->contentService,
+            $this->locationService,
+            $this->prioritizedLanguages,
+            $this->useAlwaysAvailable
+        );
+
         return $this->loadService;
+    }
+
+    /**
+     * @return \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper
+     */
+    private function getDomainObjectMapper()
+    {
+        if ($this->domainObjectMapper !== null) {
+            return $this->domainObjectMapper;
+        }
+
+        $this->domainObjectMapper = new DomainObjectMapper(
+            $this,
+            $this->contentTypeService,
+            $this->fieldTypeService
+        );
+
+        return $this->domainObjectMapper;
     }
 }

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -2,6 +2,7 @@ parameters:
     netgen.ezplatform_site.use_always_available: true
     netgen.ezplatform_site.prioritized_languages:
         - 'eng-GB'
+    netgen.ezplatform_site.root_location_id: 2
 
 services:
     netgen.ezplatform_site.inner_repository:
@@ -15,7 +16,7 @@ services:
         lazy: true
         public: false
 
-    netgen.ezplatform_site.repository.filter_service:
+    netgen.ezplatform_site.repository.filtering_search_service:
         class: %ezpublish.api.service.search.class%
         factory:
             - '@netgen.ezplatform_site.inner_repository'
@@ -23,18 +24,24 @@ services:
         lazy: true
         public: false
 
+    netgen.ezplatform_site.core.settings:
+        class: Netgen\EzPlatformSiteApi\Core\Site\Settings
+        arguments:
+            - '%netgen.ezplatform_site.prioritized_languages%'
+            - '%netgen.ezplatform_site.use_always_available%'
+            - '%netgen.ezplatform_site.root_location_id%'
+
     netgen.ezplatform_site.core.site:
         class: Netgen\EzPlatformSiteApi\Core\Site\Site
         arguments:
+            - '@netgen.ezplatform_site.core.settings'
             - '@ezpublish.api.service.content'
             - '@ezpublish.api.service.content_type'
             - '@ezpublish.api.service.field_type'
             - '@ezpublish.api.service.location'
             - '@ezpublish.api.service.search'
-            - '@netgen.ezplatform_site.repository.filter_service'
+            - '@netgen.ezplatform_site.repository.filtering_search_service'
             - '%netgen.ezplatform_site.use_always_available%'
-        calls:
-            - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
         lazy: true
 
     netgen.ezplatform_site.core.filter_service:
@@ -42,8 +49,6 @@ services:
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getFilterService
-        calls:
-            - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
         lazy: true
 
     netgen.ezplatform_site.core.find_service:
@@ -51,8 +56,6 @@ services:
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getFindService
-        calls:
-            - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
         lazy: true
 
     netgen.ezplatform_site.core.load_service:
@@ -60,6 +63,4 @@ services:
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getLoadService
-        calls:
-            - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
         lazy: true

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -25,7 +25,6 @@ services:
 
     netgen.ezplatform_site.core.site:
         class: Netgen\EzPlatformSiteApi\Core\Site\Site
-        lazy: true
         arguments:
             - '@ezpublish.api.service.content'
             - '@ezpublish.api.service.content_type'
@@ -36,12 +35,15 @@ services:
             - '%netgen.ezplatform_site.use_always_available%'
         calls:
             - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
+        lazy: true
 
     netgen.ezplatform_site.core.filter_service:
         class: Netgen\EzPlatformSiteApi\Core\Site\FilterService
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getFilterService
+        calls:
+            - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
         lazy: true
 
     netgen.ezplatform_site.core.find_service:
@@ -49,6 +51,8 @@ services:
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getFindService
+        calls:
+            - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
         lazy: true
 
     netgen.ezplatform_site.core.load_service:
@@ -56,4 +60,6 @@ services:
         factory:
             - '@netgen.ezplatform_site.core.site'
             - getLoadService
+        calls:
+            - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
         lazy: true

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -4,52 +4,6 @@ parameters:
         - 'eng-GB'
 
 services:
-    netgen.ezplatform_site.core.domain_object_mapper:
-        class: Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper
-        arguments:
-            - '@ezpublish.api.service.content_type'
-            - '@ezpublish.api.service.field_type'
-        calls:
-            - [setContainer, ['@service_container']]
-
-    netgen.ezplatform_site.core.filter_service:
-        class: Netgen\EzPlatformSiteApi\Core\Site\FilterService
-        lazy: true
-        arguments:
-            - '@netgen.ezplatform_site.core.domain_object_mapper'
-            - '@netgen.ezplatform_site.repository.filter_service'
-            - '@ezpublish.api.service.content'
-            - '%netgen.ezplatform_site.prioritized_languages%'
-            - '%netgen.ezplatform_site.use_always_available%'
-
-    netgen.ezplatform_site.core.find_service:
-        class: Netgen\EzPlatformSiteApi\Core\Site\FindService
-        lazy: true
-        arguments:
-            - '@netgen.ezplatform_site.core.domain_object_mapper'
-            - '@ezpublish.api.service.search'
-            - '@ezpublish.api.service.content'
-            - '%netgen.ezplatform_site.prioritized_languages%'
-            - '%netgen.ezplatform_site.use_always_available%'
-
-    netgen.ezplatform_site.core.load_service:
-        class: Netgen\EzPlatformSiteApi\Core\Site\LoadService
-        lazy: true
-        arguments:
-            - '@netgen.ezplatform_site.core.domain_object_mapper'
-            - '@ezpublish.api.service.content'
-            - '@ezpublish.api.service.location'
-            - '%netgen.ezplatform_site.prioritized_languages%'
-            - '%netgen.ezplatform_site.use_always_available%'
-
-    netgen.ezplatform_site.core.site:
-        class: Netgen\EzPlatformSiteApi\Core\Site\Site
-        lazy: true
-        arguments:
-            - '@netgen.ezplatform_site.filter_service'
-            - '@netgen.ezplatform_site.find_service'
-            - '@netgen.ezplatform_site.load_service'
-
     netgen.ezplatform_site.inner_repository:
         class: '%ezpublish.api.inner_repository.class%'
         factory:
@@ -68,3 +22,38 @@ services:
             - getSearchService
         lazy: true
         public: false
+
+    netgen.ezplatform_site.core.site:
+        class: Netgen\EzPlatformSiteApi\Core\Site\Site
+        lazy: true
+        arguments:
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.content_type'
+            - '@ezpublish.api.service.field_type'
+            - '@ezpublish.api.service.location'
+            - '@ezpublish.api.service.search'
+            - '@netgen.ezplatform_site.repository.filter_service'
+            - '%netgen.ezplatform_site.use_always_available%'
+        calls:
+            - [setPrioritizedLanguages, ['%netgen.ezplatform_site.prioritized_languages%']]
+
+    netgen.ezplatform_site.core.filter_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\FilterService
+        factory:
+            - '@netgen.ezplatform_site.core.site'
+            - getFilterService
+        lazy: true
+
+    netgen.ezplatform_site.core.find_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\FindService
+        factory:
+            - '@netgen.ezplatform_site.core.site'
+            - getFindService
+        lazy: true
+
+    netgen.ezplatform_site.core.load_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\LoadService
+        factory:
+            - '@netgen.ezplatform_site.core.site'
+            - getLoadService
+        lazy: true

--- a/lib/Resources/config/services.yml
+++ b/lib/Resources/config/services.yml
@@ -4,6 +4,9 @@ imports:
 parameters:
 
 services:
+    netgen.ezplatform_site.settings:
+        alias: 'netgen.ezplatform_site.core.settings'
+
     netgen.ezplatform_site.filter_service:
         alias: 'netgen.ezplatform_site.core.filter_service'
 


### PR DESCRIPTION
This refactors how services are built, replacing explicit configuration with using `Site` as factory.

Also, prioritized languages are now injected to the `Site` through setter method, which should enable updating on scope change.