### PR TITLE
Miscellaneous fixes for 2.1 release

### DIFF
--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -91,7 +91,7 @@ abstract class Content extends ValueObject
      * @param int $maxPerPage
      * @param int $currentPage
      *
-     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]|\Pagerfanta\Pagerfanta Pagerfanta instance iterating over Site API Locations
      */
     abstract public function filterLocations($maxPerPage = 25, $currentPage = 1);
 }

--- a/lib/API/Values/ContentInfo.php
+++ b/lib/API/Values/ContentInfo.php
@@ -49,7 +49,7 @@ abstract class ContentInfo extends ValueObject
      * @param int $maxPerPage
      * @param int $currentPage
      *
-     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]|\Pagerfanta\Pagerfanta Pagerfanta instance iterating over Site API Locations
      */
     abstract public function filterLocations($maxPerPage = 25, $currentPage = 1);
 }

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -47,7 +47,7 @@ abstract class Location extends ValueObject
      * @param int $maxPerPage
      * @param int $currentPage
      *
-     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[] Pagerfanta instance iterating over Site API Locations
      */
     abstract public function filterChildren(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1);
 
@@ -70,7 +70,7 @@ abstract class Location extends ValueObject
      * @param int $maxPerPage
      * @param int $currentPage
      *
-     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]|\Pagerfanta\Pagerfanta Pagerfanta instance iterating over Site API Locations
      */
     abstract public function filterSiblings(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1);
 }

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -47,7 +47,7 @@ abstract class Location extends ValueObject
      * @param int $maxPerPage
      * @param int $currentPage
      *
-     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[] Pagerfanta instance iterating over Site API Locations
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]|\Pagerfanta\Pagerfanta Pagerfanta instance iterating over Site API Locations
      */
     abstract public function filterChildren(array $contentTypeIdentifiers = [], $maxPerPage = 25, $currentPage = 1);
 

--- a/lib/API/Values/Node.php
+++ b/lib/API/Values/Node.php
@@ -3,7 +3,7 @@
 namespace Netgen\EzPlatformSiteApi\API\Values;
 
 /**
- * @deprecated Use Location with lazy loading instead.
+ * @deprecated since version 2.1, to be removed in 3.0. Use Site API Location instead.
  *
  * Node represents Site Content object on a specific Location in the content tree.
  */

--- a/lib/Core/Site/Pagination/Pagerfanta/NodeSearchAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/NodeSearchAdapter.php
@@ -3,6 +3,8 @@
 namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
 
 /**
+ * @deprecated since version 2.1, to be removed in 3.0. Use LocationSearchAdapter instead.
+ *
  * Pagerfanta adapter for Netgen eZ Platform Site Node search.
  * Will return results as Site Node objects.
  */

--- a/lib/Core/Site/Pagination/Pagerfanta/NodeSearchHitAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/NodeSearchHitAdapter.php
@@ -7,6 +7,8 @@ use Netgen\EzPlatformSiteApi\API\FindService;
 use Pagerfanta\Adapter\AdapterInterface;
 
 /**
+ * @deprecated since version 2.1, to be removed in 3.0. Use LocationSearchHitAdapter instead.
+ *
  * Pagerfanta adapter for Netgen eZ Platform Site Node search.
  * Will return results as SearchHit objects.
  */

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -2,13 +2,17 @@
 
 namespace Netgen\EzPlatformSiteApi\Core\Site\Values;
 
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\API\Repository\Values\Content\Location as RepositoryLocation;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use Netgen\EzPlatformSiteApi\API\Values\Location as APILocation;
 use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchFilterAdapter;
 use Pagerfanta\Pagerfanta;
@@ -137,7 +141,7 @@ final class Location extends APILocation
                 new LocationSearchFilterAdapter(
                     new LocationQuery([
                         'filter' => new LogicalAnd($criteria),
-                        'sortClauses' => $this->innerLocation->getSortClauses(),
+                        'sortClauses' => $this->getSortClauses(),
                     ]),
                     $this->site->getFilterService()
                 )
@@ -180,7 +184,7 @@ final class Location extends APILocation
                 new LocationSearchFilterAdapter(
                     new LocationQuery([
                         'filter' => new LogicalAnd($criteria),
-                        'sortClauses' => $this->innerLocation->getSortClauses(),
+                        'sortClauses' => $this->getSortClauses(),
                     ]),
                     $this->site->getFilterService()
                 )
@@ -232,5 +236,55 @@ final class Location extends APILocation
         }
 
         return $this->internalContent;
+    }
+
+    /**
+     * Map for Location sort fields to their respective SortClauses.
+     *
+     * Those not here (class name/identifier and modified subnode) are
+     * missing/deprecated and will most likely be removed in the future.
+     */
+    static private $sortFieldMap = [
+        RepositoryLocation::SORT_FIELD_PATH => SortClause\Location\Path::class,
+        RepositoryLocation::SORT_FIELD_PUBLISHED => SortClause\DatePublished::class,
+        RepositoryLocation::SORT_FIELD_MODIFIED => SortClause\DateModified::class,
+        RepositoryLocation::SORT_FIELD_SECTION => SortClause\SectionIdentifier::class,
+        RepositoryLocation::SORT_FIELD_DEPTH => SortClause\Location\Depth::class,
+        //RepositoryLocation::SORT_FIELD_CLASS_IDENTIFIER => false,
+        //RepositoryLocation::SORT_FIELD_CLASS_NAME => false,
+        RepositoryLocation::SORT_FIELD_PRIORITY => SortClause\Location\Priority::class,
+        RepositoryLocation::SORT_FIELD_NAME => SortClause\ContentName::class,
+        //RepositoryLocation::SORT_FIELD_MODIFIED_SUBNODE => false,
+        RepositoryLocation::SORT_FIELD_NODE_ID => SortClause\Location\Id::class,
+        RepositoryLocation::SORT_FIELD_CONTENTOBJECT_ID => SortClause\ContentId::class,
+    ];
+
+    /**
+     * Map for Location sort order to their respective Query SORT constants.
+     */
+    static private $sortOrderMap = [
+        RepositoryLocation::SORT_ORDER_DESC => Query::SORT_DESC,
+        RepositoryLocation::SORT_ORDER_ASC => Query::SORT_ASC,
+    ];
+
+    /**
+     * Get SortClause objects built from Locations's sort options.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException If sort field has a deprecated/unsupported value which does not have a Sort Clause.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\SortClause[]
+     */
+    private function getSortClauses()
+    {
+        if (!isset(static::$sortFieldMap[$this->sortField])) {
+            throw new NotImplementedException(
+                "Sort clause not implemented for Location sort field with value {$this->sortField}"
+            );
+        }
+
+        $sortClause = new static::$sortFieldMap[$this->sortField]();
+        $sortClause->direction = static::$sortOrderMap[$this->sortOrder];
+
+        return [$sortClause];
     }
 }


### PR DESCRIPTION
- fixed return type of new methods (`Pagerfanta`)
- updated deprecations, including `Node` `Pagerfanta` adapters
- implemented internal `getSortClauses()` to avoid bumping `ezpublish-kernel` to `6.7`