### PR TITLE
[2.3] Introduce simple forward relations

### DIFF
--- a/bundle/DependencyInjection/Compiler/RelationResolverRegistrationPass.php
+++ b/bundle/DependencyInjection/Compiler/RelationResolverRegistrationPass.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This compiler pass will register field type relation resolver plugins.
+ */
+final class RelationResolverRegistrationPass implements CompilerPassInterface
+{
+    /**
+     * Service ID of the resolver registry.
+     *
+     * @see \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Registry
+     *
+     * @var string
+     */
+    private $resolverRegistryId = 'netgen.ezplatform_site.plugins.field_type.relation_resolver.registry';
+
+    /**
+     * Service tag used for field type relation resolvers.
+     *
+     * @see \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver
+     *
+     * @var string
+     */
+    private $resolverTag = 'netgen.ezplatform_site.plugins.field_type.relation_resolver';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has($this->resolverRegistryId)) {
+            return;
+        }
+
+        $resolverRegistryDefinition = $container->getDefinition($this->resolverRegistryId);
+
+        $resolvers = $container->findTaggedServiceIds($this->resolverTag);
+
+        foreach ($resolvers as $id => $attributes) {
+            /** @var array $attributes */
+            $this->registerResolver($resolverRegistryDefinition, $id, $attributes);
+        }
+    }
+
+    /**
+     * Add method call to register resolver with given $id with resolver registry.
+     *
+     * @throws \LogicException
+     *
+     * @param \Symfony\Component\DependencyInjection\Definition $resolverRegistryDefinition
+     * @param string $id
+     * @param array $attributes
+     *
+     * @return void
+     */
+    private function registerResolver(Definition $resolverRegistryDefinition, $id, array $attributes)
+    {
+        foreach ($attributes as $attribute) {
+            if (!isset($attribute['identifier'])) {
+                throw new LogicException(
+                    "'{$this->resolverTag}' service tag needs an 'identifier' attribute to identify the field type"
+                );
+            }
+
+            $resolverRegistryDefinition->addMethodCall(
+                'register',
+                [
+                    $attribute['identifier'],
+                    new Reference($id),
+                ]
+            );
+        }
+    }
+}

--- a/bundle/NetgenEzPlatformSiteApiBundle.php
+++ b/bundle/NetgenEzPlatformSiteApiBundle.php
@@ -4,6 +4,7 @@ namespace Netgen\Bundle\EzPlatformSiteApiBundle;
 
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\DefaultViewActionOverridePass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\PreviewControllerOverridePass;
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\ViewBuilderRegistrationPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Configuration\Parser\ContentView;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -17,6 +18,7 @@ class NetgenEzPlatformSiteApiBundle extends Bundle
 
         $container->addCompilerPass(new DefaultViewActionOverridePass());
         $container->addCompilerPass(new PreviewControllerOverridePass());
+        $container->addCompilerPass(new RelationResolverRegistrationPass());
         $container->addCompilerPass(new ViewBuilderRegistrationPass());
 
         /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $coreExtension */

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "ezsystems/ezpublish-kernel": "^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.7"
+        "phpunit/phpunit": "^4.8.35|^5.7",
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/lib/API/RelationService.php
+++ b/lib/API/RelationService.php
@@ -8,8 +8,30 @@ namespace Netgen\EzPlatformSiteApi\API;
 interface RelationService
 {
     /**
-     * Load related Content from $fieldDefinitionIdentifier field in Content with given $contentId,
-     * optionally limited by a list of $contentTypeIdentifiers.
+     * Load single related Content from $fieldDefinitionIdentifier field in Content with given
+     * $contentId, optionally limited by a list of $contentTypeIdentifiers.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue If the $fieldDefinitionIdentifier does
+     *         not exist in the Content with given $contentId
+     *
+     * @param $contentId
+     * @param $fieldDefinitionIdentifier
+     * @param array $contentTypeIdentifiers
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content|null
+     */
+    public function loadFieldRelation(
+        $contentId,
+        $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = []
+    );
+
+    /**
+     * Load all related Content from $fieldDefinitionIdentifier field in Content with given
+     * $contentId, optionally limited by a list of $contentTypeIdentifiers and $limit.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue If the $fieldDefinitionIdentifier does
+     *         not exist in the Content with given $contentId
      *
      * @param int|string $contentId
      * @param string $fieldDefinitionIdentifier
@@ -17,5 +39,9 @@ interface RelationService
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
      */
-    public function loadFieldRelations($contentId, $fieldDefinitionIdentifier, array $contentTypeIdentifiers = []);
+    public function loadFieldRelations(
+        $contentId,
+        $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = []
+    );
 }

--- a/lib/API/RelationService.php
+++ b/lib/API/RelationService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\API;
+
+/**
+ * Relation service provides methods for loading relations.
+ */
+interface RelationService
+{
+    /**
+     * Load related Content from $fieldDefinitionIdentifier field in Content with given $contentId,
+     * optionally limited by a list of $contentTypeIdentifiers.
+     *
+     * @param int|string $contentId
+     * @param string $fieldDefinitionIdentifier
+     * @param array $contentTypeIdentifiers
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
+     */
+    public function loadFieldRelations($contentId, $fieldDefinitionIdentifier, array $contentTypeIdentifiers = []);
+}

--- a/lib/API/Site.php
+++ b/lib/API/Site.php
@@ -34,4 +34,11 @@ interface Site
      * @return \Netgen\EzPlatformSiteApi\API\LoadService
      */
     public function getLoadService();
+
+    /**
+     * RelationService getter.
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\RelationService
+     */
+    public function getRelationService();
 }

--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -98,4 +98,27 @@ abstract class Content extends ValueObject
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]|\Pagerfanta\Pagerfanta Pagerfanta instance iterating over Site API Locations
      */
     abstract public function filterLocations($maxPerPage = 25, $currentPage = 1);
+
+    /**
+     * Return related Content from $fieldDefinitionIdentifier field in Content with given $contentId.
+     *
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
+     */
+    abstract public function getFieldRelations($fieldDefinitionIdentifier);
+
+    /**
+     * Return related Content from $fieldDefinitionIdentifier field in Content with given $contentId,
+     * optionally limited by a list of $contentTypeIdentifiers.
+     *
+     * @param string $fieldDefinitionIdentifier
+     * @param string[] $contentTypeIdentifiers
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
+     */
+    abstract public function filterFieldRelations(
+        $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = []
+    );
 }

--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -100,13 +100,23 @@ abstract class Content extends ValueObject
     abstract public function filterLocations($maxPerPage = 25, $currentPage = 1);
 
     /**
-     * Return related Content from $fieldDefinitionIdentifier field in Content with given $contentId.
+     * Return single related Content from $fieldDefinitionIdentifier field.
      *
      * @param string $fieldDefinitionIdentifier
      *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content|null
+     */
+    abstract public function getFieldRelation($fieldDefinitionIdentifier);
+
+    /**
+     * Return all related Content from $fieldDefinitionIdentifier.
+     *
+     * @param string $fieldDefinitionIdentifier
+     * @param int $limit
+     *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
      */
-    abstract public function getFieldRelations($fieldDefinitionIdentifier);
+    abstract public function getFieldRelations($fieldDefinitionIdentifier, $limit = 25);
 
     /**
      * Return related Content from $fieldDefinitionIdentifier field in Content with given $contentId,
@@ -114,11 +124,16 @@ abstract class Content extends ValueObject
      *
      * @param string $fieldDefinitionIdentifier
      * @param string[] $contentTypeIdentifiers
+     * @param int $maxPerPage
+     * @param int $currentPage
      *
-     * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]|\Pagerfanta\Pagerfanta
+     *         Pagerfanta instance iterating over Site API Content items
      */
     abstract public function filterFieldRelations(
         $fieldDefinitionIdentifier,
-        array $contentTypeIdentifiers = []
+        array $contentTypeIdentifiers = [],
+        $maxPerPage = 25,
+        $currentPage = 1
     );
 }

--- a/lib/Core/Site/Plugins/FieldType/RelationResolver/Registry.php
+++ b/lib/Core/Site/Plugins/FieldType/RelationResolver/Registry.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver;
+
+use OutOfBoundsException;
+
+/**
+ * Registry for field type relation resolvers.
+ *
+ * @see \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver
+ */
+class Registry
+{
+    /**
+     * Map of resolvers by field type identifier.
+     *
+     * @var \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver[]
+     */
+    protected $resolverMap = array();
+
+    /**
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver[] $resolverMap
+     */
+    public function __construct(array $resolverMap = [])
+    {
+        foreach ($resolverMap as $fieldTypeIdentifier => $resolver) {
+            $this->register($fieldTypeIdentifier, $resolver);
+        }
+    }
+
+    /**
+     * Register a $resolver for $fieldTypeIdentifier.
+     *
+     * @param string $fieldTypeIdentifier
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver $resolver
+     *
+     * @return void
+     */
+    public function register($fieldTypeIdentifier, Resolver $resolver)
+    {
+        $this->resolverMap[$fieldTypeIdentifier] = $resolver;
+    }
+
+    /**
+     * Returns Resolver for $fieldTypeIdentifier.
+     *
+     * @throws \OutOfBoundsException When there is no resolver for the given $fieldTypeIdentifier
+     *
+     * @param string $fieldTypeIdentifier
+     *
+     * @return \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver
+     */
+    public function get($fieldTypeIdentifier)
+    {
+        if (isset($this->resolverMap[$fieldTypeIdentifier])) {
+            return $this->resolverMap[$fieldTypeIdentifier];
+        }
+
+        throw new OutOfBoundsException(
+            "No relation resolver is registered for field type identifier '{$fieldTypeIdentifier}'"
+        );
+    }
+}

--- a/lib/Core/Site/Plugins/FieldType/RelationResolver/Resolver.php
+++ b/lib/Core/Site/Plugins/FieldType/RelationResolver/Resolver.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver;
+
+use eZ\Publish\SPI\FieldType\Value;
+use LogicException;
+use Netgen\EzPlatformSiteApi\API\Values\Field;
+
+/**
+ * Field type relation resolver returns related Content IDs for a Content field
+ * of a specific field type.
+ *
+ * If a field type is to be used for relations, it needs a dedicated implementation
+ * of this class to be registered with resolver registry.
+ *
+ * @see \Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass
+ */
+abstract class Resolver
+{
+    /**
+     * Return accepted field type identifier.
+     *
+     * @return string
+     */
+    abstract protected function getSupportedFieldTypeIdentifier();
+
+    /**
+     * Return related Content IDs for the given $field.
+     *
+     * @param \eZ\Publish\SPI\FieldType\Value $value
+     *
+     * @return mixed
+     */
+    abstract protected function getRelationIdsFromValue(Value $value);
+
+    /**
+     * Check if the given $field is of the accepted field type.
+     *
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field
+     *
+     * @return bool
+     */
+    protected function accept(Field $field)
+    {
+        return $field->fieldTypeIdentifier === $this->getSupportedFieldTypeIdentifier();
+    }
+
+    /**
+     * Return related Content IDs for the given $field.
+     *
+     * @throws \LogicException If the field can't be handled by the resolver
+     *
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field
+     *
+     * @return int[]|string[]
+     */
+    public function getRelationIds(Field $field)
+    {
+        if (!$this->accept($field)) {
+            $identifier = $this->getSupportedFieldTypeIdentifier();
+
+            throw new LogicException(
+                "This resolver can only handle fields of '{$identifier}' type"
+            );
+        }
+
+        return $this->getRelationIdsFromValue($field->value);
+    }
+}

--- a/lib/Core/Site/Plugins/FieldType/RelationResolver/Resolver/Relation.php
+++ b/lib/Core/Site/Plugins/FieldType/RelationResolver/Resolver/Relation.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver;
+
+use eZ\Publish\SPI\FieldType\Value;
+use Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver;
+
+/**
+ * Relation field type relation Resolver.
+ *
+ * @see \eZ\Publish\Core\FieldType\Relation
+ */
+class Relation extends Resolver
+{
+    protected function getSupportedFieldTypeIdentifier()
+    {
+        return 'ezobjectrelation';
+    }
+
+    protected function getRelationIdsFromValue(Value $value)
+    {
+        /** @var \eZ\Publish\Core\FieldType\Relation\Value $value */
+        return [$value->destinationContentId];
+    }
+}

--- a/lib/Core/Site/Plugins/FieldType/RelationResolver/Resolver/RelationList.php
+++ b/lib/Core/Site/Plugins/FieldType/RelationResolver/Resolver/RelationList.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver;
+
+use eZ\Publish\SPI\FieldType\Value;
+use Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver;
+
+/**
+ * RelationList field type relation resolver.
+ *
+ * @see \eZ\Publish\Core\FieldType\RelationList
+ */
+class RelationList extends Resolver
+{
+    protected function getSupportedFieldTypeIdentifier()
+    {
+        return 'ezobjectrelationlist';
+    }
+
+    protected function getRelationIdsFromValue(Value $value)
+    {
+        /** @var \eZ\Publish\Core\FieldType\RelationList\Value $value */
+        return $value->destinationContentIds;
+    }
+}

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site;
+
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use Netgen\EzPlatformSiteApi\API\RelationService as RelationServiceInterface;
+use Netgen\EzPlatformSiteApi\API\Site;
+use Netgen\EzPlatformSiteApi\API\Values\Content;
+
+class RelationService implements RelationServiceInterface
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\Site
+     */
+    private $site;
+
+    /**
+     * @param \Netgen\EzPlatformSiteApi\API\Site $site
+     */
+    public function __construct(Site $site)
+    {
+        $this->site = $site;
+    }
+
+    public function loadFieldRelations($contentId, $fieldDefinitionIdentifier, array $contentTypeIdentifiers = [])
+    {
+        $content = $this->site->getLoadService()->loadContent($contentId);
+
+        $field = $content->getField($fieldDefinitionIdentifier);
+        if ($field->fieldTypeIdentifier !== 'ezobjectrelationlist') {
+            throw new NotImplementedException(
+                'Loading field relations is supported only for RelationList field type'
+            );
+        }
+
+        /** @var \eZ\Publish\Core\FieldType\RelationList\Value $value */
+        $value = $field->value;
+        $relatedContentIdList = $value->destinationContentIds;
+        $criteria = [];
+
+        $criteria[] = new ContentId($relatedContentIdList);
+        if (!empty($contentTypeIdentifiers)) {
+            $criteria[] = new ContentTypeIdentifier($contentTypeIdentifiers);
+        }
+
+        if (count($criteria) > 1) {
+            $criteria = new LogicalAnd($criteria);
+        } else {
+            $criteria = reset($criteria);
+        }
+
+        $query = new Query([
+            'filter' => $criteria,
+            'limit' => count($relatedContentIdList),
+        ]);
+
+        $searchResult = $this->site->getFilterService()->filterContent($query);
+        $relatedContentList = array_map(
+            function(SearchHit $searchHit) {
+                return $searchHit->valueObject;
+            },
+            $searchResult->searchHits
+        );
+
+        $sortedIdList = array_flip($relatedContentIdList);
+        $sorter = function (Content $content1, Content $content2) use ($sortedIdList) {
+            if ($content1->id === $content2->id) {
+                return 0;
+            }
+
+            return ($sortedIdList[$content1->id] < $sortedIdList[$content2->id]) ? -1 : 1;
+        };
+        usort($relatedContentList, $sorter);
+
+        return $relatedContentList;
+    }
+}

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -9,7 +9,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifi
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use Netgen\EzPlatformSiteApi\API\RelationService as RelationServiceInterface;
-use Netgen\EzPlatformSiteApi\API\Site;
+use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
 use Netgen\EzPlatformSiteApi\API\Values\Content;
 
 class RelationService implements RelationServiceInterface
@@ -22,7 +22,7 @@ class RelationService implements RelationServiceInterface
     /**
      * @param \Netgen\EzPlatformSiteApi\API\Site $site
      */
-    public function __construct(Site $site)
+    public function __construct(SiteInterface $site)
     {
         $this->site = $site;
     }

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -2,72 +2,133 @@
 
 namespace Netgen\EzPlatformSiteApi\Core\Site;
 
-use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
-use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use Netgen\EzPlatformSiteApi\API\RelationService as RelationServiceInterface;
 use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
 use Netgen\EzPlatformSiteApi\API\Values\Content;
+use Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Registry as RelationResolverRegistry;
+use Netgen\EzPlatformSiteApi\Core\Traits\SearchResultExtractorTrait;
 
 class RelationService implements RelationServiceInterface
 {
+    use SearchResultExtractorTrait;
+
     /**
      * @var \Netgen\EzPlatformSiteApi\API\Site
      */
     private $site;
 
     /**
-     * @param \Netgen\EzPlatformSiteApi\API\Site $site
+     * @var \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Registry
      */
-    public function __construct(SiteInterface $site)
-    {
+    private $relationResolverRegistry;
+
+    /**
+     * @param \Netgen\EzPlatformSiteApi\API\Site $site
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Registry $relationResolverRegistry
+     */
+    public function __construct(
+        SiteInterface $site,
+        RelationResolverRegistry $relationResolverRegistry
+    ) {
         $this->site = $site;
+        $this->relationResolverRegistry = $relationResolverRegistry;
     }
 
-    public function loadFieldRelations($contentId, $fieldDefinitionIdentifier, array $contentTypeIdentifiers = [])
-    {
+    public function loadFieldRelation(
+        $contentId,
+        $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = []
+    ) {
+        $relatedContentItems = $this->loadFieldRelations(
+            $contentId,
+            $fieldDefinitionIdentifier,
+            $contentTypeIdentifiers
+        );
+
+        return count($relatedContentItems) ? reset($relatedContentItems) : null;
+    }
+
+    public function loadFieldRelations(
+        $contentId,
+        $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = []
+    ) {
         $content = $this->site->getLoadService()->loadContent($contentId);
 
-        $field = $content->getField($fieldDefinitionIdentifier);
-        if ($field->fieldTypeIdentifier !== 'ezobjectrelationlist') {
-            throw new NotImplementedException(
-                'Loading field relations is supported only for RelationList field type'
+        if (!$content->hasField($fieldDefinitionIdentifier)) {
+            throw new InvalidArgumentException(
+                '$fieldDefinitionIdentifier',
+                "Content does not contain a field '{$fieldDefinitionIdentifier}'"
             );
         }
 
-        /** @var \eZ\Publish\Core\FieldType\RelationList\Value $value */
-        $value = $field->value;
-        $relatedContentIdList = $value->destinationContentIds;
-        $criteria = [];
+        $field = $content->getField($fieldDefinitionIdentifier);
+        $relationResolver = $this->relationResolverRegistry->get($field->fieldTypeIdentifier);
 
-        $criteria[] = new ContentId($relatedContentIdList);
-        if (!empty($contentTypeIdentifiers)) {
-            $criteria[] = new ContentTypeIdentifier($contentTypeIdentifiers);
+        $relatedContentIds = $relationResolver->getRelationIds($field);
+        $relatedContentItems = $this->getRelatedContentItems(
+            $relatedContentIds,
+            $contentTypeIdentifiers
+        );
+        $this->sortByIdOrder($relatedContentItems, $relatedContentIds);
+
+        return $relatedContentItems;
+    }
+
+    /**
+     * Return an array of related Content from the given arguments.
+     *
+     * @throws \InvalidArgumentException As thrown by the Search API
+     *
+     * @param array $relatedContentIds
+     * @param array $contentTypeIdentifiers
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content[]
+     */
+    private function getRelatedContentItems(array $relatedContentIds, array $contentTypeIdentifiers)
+    {
+        if (count($relatedContentIds) === 0) {
+            return [];
         }
 
-        if (count($criteria) > 1) {
-            $criteria = new LogicalAnd($criteria);
-        } else {
-            $criteria = reset($criteria);
+        $criteria = new ContentId($relatedContentIds);
+
+        if (!empty($contentTypeIdentifiers)) {
+            $criteria = new LogicalAnd([
+                $criteria,
+                new ContentTypeIdentifier($contentTypeIdentifiers),
+            ]);
         }
 
         $query = new Query([
             'filter' => $criteria,
-            'limit' => count($relatedContentIdList),
+            'limit' => count($relatedContentIds),
         ]);
 
         $searchResult = $this->site->getFilterService()->filterContent($query);
-        $relatedContentList = array_map(
-            function(SearchHit $searchHit) {
-                return $searchHit->valueObject;
-            },
-            $searchResult->searchHits
-        );
+        /** @var \eZ\Publish\API\Repository\Values\Content\Content[] $contentItems */
+        $contentItems = $this->extractValueObjects($searchResult);
 
-        $sortedIdList = array_flip($relatedContentIdList);
+        return $contentItems;
+    }
+
+    /**
+     * Sorts $relatedContentItems to match order from $relatedContentIds.
+     *
+     * @param array $relatedContentItems
+     * @param array $relatedContentIds
+     *
+     * @return void
+     */
+    private function sortByIdOrder(array &$relatedContentItems, array $relatedContentIds)
+    {
+        $sortedIdList = array_flip($relatedContentIds);
+
         $sorter = function (Content $content1, Content $content2) use ($sortedIdList) {
             if ($content1->id === $content2->id) {
                 return 0;
@@ -75,8 +136,7 @@ class RelationService implements RelationServiceInterface
 
             return ($sortedIdList[$content1->id] < $sortedIdList[$content2->id]) ? -1 : 1;
         };
-        usort($relatedContentList, $sorter);
 
-        return $relatedContentList;
+        usort($relatedContentItems, $sorter);
     }
 }

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -10,6 +10,7 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\UserService;
 use Netgen\EzPlatformSiteApi\API\Settings as BaseSite;
 use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
+use Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Registry as RelationResolverRegistry;
 
 class Site implements SiteInterface
 {
@@ -64,6 +65,11 @@ class Site implements SiteInterface
     private $filterService;
 
     /**
+     * @var \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Registry
+     */
+    private $relationResolverRegistry;
+
+    /**
      * @var \Netgen\EzPlatformSiteApi\API\FindService
      */
     private $findService;
@@ -87,6 +93,7 @@ class Site implements SiteInterface
      * @param \eZ\Publish\API\Repository\SearchService $searchService
      * @param \eZ\Publish\API\Repository\SearchService $filteringSearchService
      * @param \eZ\Publish\API\Repository\UserService $userService
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Registry $relationResolverRegistry
      */
     public function __construct(
         BaseSite $settings,
@@ -96,7 +103,8 @@ class Site implements SiteInterface
         LocationService $locationService,
         SearchService $searchService,
         SearchService $filteringSearchService,
-        UserService $userService
+        UserService $userService,
+        RelationResolverRegistry $relationResolverRegistry
     ) {
         $this->settings = $settings;
         $this->contentService = $contentService;
@@ -106,6 +114,7 @@ class Site implements SiteInterface
         $this->searchService = $searchService;
         $this->filteringSearchService = $filteringSearchService;
         $this->userService = $userService;
+        $this->relationResolverRegistry = $relationResolverRegistry;
     }
 
     public function getSettings()
@@ -158,7 +167,10 @@ class Site implements SiteInterface
     public function getRelationService()
     {
         if ($this->relationService === null) {
-            $this->relationService = new RelationService($this);
+            $this->relationService = new RelationService(
+                $this,
+                $this->relationResolverRegistry
+            );
         }
 
         return $this->relationService;

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -74,6 +74,11 @@ class Site implements SiteInterface
     private $loadService;
 
     /**
+     * @var \Netgen\EzPlatformSiteApi\API\RelationService
+     */
+    private $relationService;
+
+    /**
      * @param \Netgen\EzPlatformSiteApi\API\Settings $settings
      * @param \eZ\Publish\API\Repository\ContentService $contentService
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
@@ -148,6 +153,15 @@ class Site implements SiteInterface
         }
 
         return $this->loadService;
+    }
+
+    public function getRelationService()
+    {
+        if ($this->relationService === null) {
+            $this->relationService = new RelationService($this);
+        }
+
+        return $this->relationService;
     }
 
     /**

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -10,6 +10,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use Netgen\EzPlatformSiteApi\API\Values\Content as APIContent;
 use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchFilterAdapter;
+use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 
 /**
@@ -362,23 +363,43 @@ final class Content extends APIContent
         return $this->innerOwnerUser;
     }
 
-    public function getFieldRelations($fieldDefinitionIdentifier)
+    public function getFieldRelation($fieldDefinitionIdentifier)
     {
-        return $this->site->getRelationService()->loadFieldRelations(
+        return $this->site->getRelationService()->loadFieldRelation(
             $this->id,
             $fieldDefinitionIdentifier
         );
     }
 
+    public function getFieldRelations($fieldDefinitionIdentifier, $limit = 25)
+    {
+        $relations = $this->site->getRelationService()->loadFieldRelations(
+            $this->id,
+            $fieldDefinitionIdentifier
+        );
+
+        return array_slice($relations, 0, $limit);
+    }
+
     public function filterFieldRelations(
         $fieldDefinitionIdentifier,
-        array $contentTypeIdentifiers = []
+        array $contentTypeIdentifiers = [],
+        $maxPerPage = 25,
+        $currentPage = 1
     ) {
-        return $this->site->getRelationService()->loadFieldRelations(
+        $relations = $this->site->getRelationService()->loadFieldRelations(
             $this->id,
             $fieldDefinitionIdentifier,
             $contentTypeIdentifiers
         );
+
+        $pager = new Pagerfanta(new ArrayAdapter($relations));
+
+        $pager->setNormalizeOutOfRangePages(true);
+        $pager->setMaxPerPage($maxPerPage);
+        $pager->setCurrentPage($currentPage);
+
+        return $pager;
     }
 
     public function __debugInfo()

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -362,6 +362,25 @@ final class Content extends APIContent
         return $this->innerOwnerUser;
     }
 
+    public function getFieldRelations($fieldDefinitionIdentifier)
+    {
+        return $this->site->getRelationService()->loadFieldRelations(
+            $this->id,
+            $fieldDefinitionIdentifier
+        );
+    }
+
+    public function filterFieldRelations(
+        $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = []
+    ) {
+        return $this->site->getRelationService()->loadFieldRelations(
+            $this->id,
+            $fieldDefinitionIdentifier,
+            $contentTypeIdentifiers
+        );
+    }
+
     public function __debugInfo()
     {
         $this->initializeFields();

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -65,3 +65,10 @@ services:
             - '@netgen.ezplatform_site.core.site'
             - getLoadService
         lazy: true
+
+    netgen.ezplatform_site.core.relation_service:
+        class: Netgen\EzPlatformSiteApi\Core\Site\RelationService
+        factory:
+            - '@netgen.ezplatform_site.core.site'
+            - getRelationService
+        lazy: true

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -43,6 +43,7 @@ services:
             - '@ezpublish.api.service.search'
             - '@netgen.ezplatform_site.repository.filtering_search_service'
             - '@ezpublish.api.service.user'
+            - '@netgen.ezplatform_site.plugins.field_type.relation_resolver.registry'
         lazy: true
 
     netgen.ezplatform_site.core.filter_service:

--- a/lib/Resources/config/plugins/field_type/relation_resolvers.yml
+++ b/lib/Resources/config/plugins/field_type/relation_resolvers.yml
@@ -1,0 +1,19 @@
+parameters:
+
+services:
+    # Services tagged with 'netgen.ezplatform_site.plugins.field_type.relation_resolver'
+    # register to Registry through a compiler pass
+    netgen.ezplatform_site.plugins.field_type.relation_resolver.registry:
+        class: Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Registry
+
+    # Resolver for Relation field type
+    netgen.ezplatform_site.plugins.field_type.relation_resolver.relation:
+        class: Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver\Relation
+        tags:
+            - {name: netgen.ezplatform_site.plugins.field_type.relation_resolver, identifier: ezobjectrelation}
+
+    # Resolver for RelationList field type
+    netgen.ezplatform_site.plugins.field_type.relation_resolver.relation_list:
+        class: Netgen\EzPlatformSiteApi\Core\Site\Plugins\FieldType\RelationResolver\Resolver\RelationList
+        tags:
+            - {name: netgen.ezplatform_site.plugins.field_type.relation_resolver, identifier: ezobjectrelationlist}

--- a/lib/Resources/config/services.yml
+++ b/lib/Resources/config/services.yml
@@ -1,5 +1,6 @@
 imports:
     - {resource: internal.yml}
+    - {resource: plugins/field_type/relation_resolvers.yml}
 
 parameters:
 

--- a/lib/Resources/config/services.yml
+++ b/lib/Resources/config/services.yml
@@ -16,6 +16,9 @@ services:
     netgen.ezplatform_site.load_service:
         alias: 'netgen.ezplatform_site.core.load_service'
 
+    netgen.ezplatform_site.relation_service:
+        alias: 'netgen.ezplatform_site.core.relation_service'
+
     netgen.ezplatform_site.site:
         alias: 'netgen.ezplatform_site.core.site'
 

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -15,6 +15,7 @@
             <file>tests/lib/Integration/SiteTest.php</file>
             <file>tests/lib/Integration/FindServiceTest.php</file>
             <file>tests/lib/Integration/LoadServiceTest.php</file>
+            <file>tests/lib/Integration/RelationServiceTest.php</file>
             <file>tests/lib/Integration/Traits/SearchResultExtractorTraitTest.php</file>
         </testsuite>
     </testsuites>

--- a/tests/bundle/DependencyInjection/Compiler/RelationResolverRegistrationPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/RelationResolverRegistrationPassTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Tests\DependencyInjection\Compiler;
+
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class RelationResolverRegistrationPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setDefinition(
+            'netgen.ezplatform_site.plugins.field_type.relation_resolver.registry',
+            new Definition()
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RelationResolverRegistrationPass());
+    }
+
+    public function testRegisterResolver()
+    {
+        $fieldTypeIdentifier = 'field_type_identifier';
+        $serviceId = 'service_id';
+        $definition = new Definition();
+        $definition->addTag(
+            'netgen.ezplatform_site.plugins.field_type.relation_resolver',
+            ['identifier' => $fieldTypeIdentifier]
+        );
+        $this->setDefinition($serviceId, $definition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'netgen.ezplatform_site.plugins.field_type.relation_resolver.registry',
+            'register',
+            [$fieldTypeIdentifier, $serviceId]
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testRegisterResolverWithoutIdentifier()
+    {
+        $serviceId = 'service_id';
+        $definition = new Definition();
+        $definition->addTag('netgen.ezplatform_site.plugins.field_type.relation_resolver');
+        $this->setDefinition($serviceId, $definition);
+
+        $this->compile();
+    }
+}

--- a/tests/lib/Integration/RelationServiceTest.php
+++ b/tests/lib/Integration/RelationServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Tests\Integration;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use Netgen\EzPlatformSiteApi\API\Values\Content;
+
+/**
+ * Test case for the RelationService.
+ *
+ * @see \Netgen\EzPlatformSiteApi\API\RelationService
+ *
+ * @group integration
+ * @group relation
+ */
+class RelationServiceTest extends BaseTest
+{
+    public function testPrepareTestContent()
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+        $contentService = $repository->getContentService();
+        $languageCode = 'eng-GB';
+        $relationId = 57;
+        $relationIds = [57, 58];
+        $fieldDefinitionIdentifier = 'relation';
+
+        $contentTypeGroup = $contentTypeService->loadContentTypeGroup(1);
+
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('test_relation');
+        $contentTypeCreateStruct->mainLanguageCode = $languageCode;
+        $contentTypeCreateStruct->names = [$languageCode => 'Test Relation'];
+        $contentTypeCreateStruct->addFieldDefinition(
+            new FieldDefinitionCreateStruct([
+                'identifier' => $fieldDefinitionIdentifier,
+                'fieldTypeIdentifier' => 'ezobjectrelation',
+            ])
+        );
+        $contentTypeDraft = $contentTypeService->createContentType($contentTypeCreateStruct, [$contentTypeGroup]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentTypeDraft, $languageCode);
+        $contentCreateStruct->setField($fieldDefinitionIdentifier, $relationId);
+        $contentDraft = $contentService->createContent($contentCreateStruct);
+        $relationContent = $contentService->publishVersion($contentDraft->versionInfo);
+
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('test_relation_list');
+        $contentTypeCreateStruct->mainLanguageCode = $languageCode;
+        $contentTypeCreateStruct->names = [$languageCode => 'Test RelationList'];
+        $contentTypeCreateStruct->addFieldDefinition(
+            new FieldDefinitionCreateStruct([
+                'identifier' => $fieldDefinitionIdentifier,
+                'fieldTypeIdentifier' => 'ezobjectrelationlist',
+            ])
+        );
+        $contentTypeDraft = $contentTypeService->createContentType($contentTypeCreateStruct, [$contentTypeGroup]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentTypeDraft, $languageCode);
+        $contentCreateStruct->setField($fieldDefinitionIdentifier, $relationIds);
+        $contentDraft = $contentService->createContent($contentCreateStruct);
+        $relationListContent = $contentService->publishVersion($contentDraft->versionInfo);
+
+        return [$fieldDefinitionIdentifier, $relationContent, $relationId, $relationListContent, $relationIds];
+    }
+
+    /**
+     * @depends testPrepareTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content[] $testContentItems
+     */
+    public function testLoadFieldRelation(array $testContentItems)
+    {
+        list($identifier, $testApiContent, $testRelationId) = $testContentItems;
+
+        $relationService = $this->getSite()->getRelationService();
+        $content = $relationService->loadFieldRelation($testApiContent->id, $identifier);
+
+        $this->assertInstanceOf(Content::class, $content);
+        $this->assertEquals($testRelationId, $content->id);
+    }
+
+    /**
+     * @depends testPrepareTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content[] $testContentItems
+     */
+    public function testLoadFieldRelations(array $testContentItems)
+    {
+        list($identifier, , , $testApiContent, $testRelationIds) = $testContentItems;
+
+        $relationService = $this->getSite()->getRelationService();
+        $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier);
+
+        $this->assertEquals(count($testRelationIds), count($contentItems));
+
+        foreach ($testRelationIds as $index => $relationId) {
+            $content = $contentItems[$index];
+            $this->assertInstanceOf(Content::class, $content);
+            $this->assertEquals($relationId, $content->id);
+        }
+    }
+}

--- a/tests/lib/Integration/SetupFactory/Legacy.php
+++ b/tests/lib/Integration/SetupFactory/Legacy.php
@@ -4,6 +4,7 @@ namespace Netgen\EzPlatformSiteApi\Tests\Integration\SetupFactory;
 
 use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy as CoreLegacySetupFactory;
 use eZ\Publish\Core\Base\ServiceContainer;
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
@@ -18,8 +19,11 @@ class Legacy extends CoreLegacySetupFactory
         if (null === self::$serviceContainer) {
             $config = include __DIR__ . '/../../../../vendor/ezsystems/ezpublish-kernel/config.php';
             $installDir = $config['install_dir'];
+
             /* @var \Symfony\Component\DependencyInjection\ContainerBuilder $containerBuilder */
             $containerBuilder = include $config['container_builder_path'];
+            $containerBuilder->addCompilerPass(new RelationResolverRegistrationPass());
+
             /* @var \Symfony\Component\DependencyInjection\Loader\YamlFileLoader $loader */
             $loader->load('search_engines/legacy.yml');
             $loader->load('tests/integration_legacy.yml');


### PR DESCRIPTION
This introduces `RelationService` with a (for now) single method:

`loadFieldRelations($contentId, $fieldIdentifier, array $contentTypeIdentifiers = [])`

The method will return **all** forward related Content of a given field.
Note:
1. No filtering on Location visibility is done
2. No offset or limit is provided as with current implementation we need to load all relations anyway

In future that might change as we might implement search (filtering) support for forward and reverse relations and something called `LocationQueryCriterion` to enable grouping of Location conditions in Content search.

On the `Content` object two new methods are added:
- `getFieldRelations($fieldDefinitionIdentifier)`
- `filterFieldRelations($fieldDefinitionIdentifier, array $contentTypeIdentifiers = [])`

For Twig the usage looks like this:

```twig
<ul>
{% for wine in content.fieldRelations('wine') %}
    <li>{{ wine.name }}</li>
{% endfor %}
</ul>
```

```twig
<ul>
{% for cheese in content.filterFieldRelations('cheese', ['cheese'])|slice(0, 5) %}
    <li>{{ cheese.name }}</li>
{% endfor %}
</ul>
```