### PR TITLE
Prepare release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ eZ Platform Site API changelog
 ------------------
 
 * Introduces lazy loading of `Content` fields, meaning that fields will be transparently loaded only
-if accessed.
+if accessed
+* Introduces lazy loading of `ContentInfo` when accessed from `Content` or `Location`
 * Deprecates all methods to obtain `ContentInfo` object (to be removed in 3.0):
   * `LoadService::loadContentInfo()`
   * `LoadService::loadContentInfoByRemoteId()`
@@ -18,6 +19,7 @@ if accessed.
 * Deprecates ContentInfo Pagerfanta search adapters (to be removed in 3.0):
   * `ContentInfoSearchAdapter`
   * `ContentInfoSearchHitAdapter`
+* Fixes https://github.com/netgen/ezplatform-site-api/issues/48: Mapping a field takes the wrong ID
 
 2.1.1 (07.09.2017)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ if accessed
   * `FilterService::filterContentInfo()`
   * `FindService::findContentInfo()`
 
+  The intention behind this is that, with lazy loading of `Content` fields, `Content` takes over the
+  role of `ContentInfo`. It basically behaves the same until the fields are accessed, so you don't
+  need to think about it. 
+
   Note that `ContentInfo` itself is not deprecated, for the sole reason of keeping Site API in line
-  with Repository API. With 3.0, the only way to access `ContentInfo` object will be through
+  with Repository API. With 3.0 the only way to access `ContentInfo` object will be through
   aggregation in `Content` and `Location` objects.
 * Deprecates ContentInfo Pagerfanta search adapters (to be removed in 3.0):
   * `ContentInfoSearchAdapter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 eZ Platform Site API changelog
 ==============================
 
-2.2.0 (??.??.????)
-------------------
+2.2.0 (05.10.2017.)
+-------------------
 
 * Introduces lazy loading of `Content` fields, meaning that fields will be transparently loaded only
 if accessed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 eZ Platform Site API changelog
 ==============================
 
+2.2.0 (??.??.????)
+------------------
+
+* Introduces lazy loading of `Content` fields, meaning that fields will be transparently loaded only
+if accessed.
+* Deprecates all methods to obtain `ContentInfo` object (to be removed in 3.0):
+  * `LoadService::loadContentInfo()`
+  * `LoadService::loadContentInfoByRemoteId()`
+  * `FilterService::filterContentInfo()`
+  * `FindService::findContentInfo()`
+
+  Note that `ContentInfo` itself is not deprecated, for the sole reason of keeping Site API in line
+  with Repository API. With 3.0, the only way to access `ContentInfo` object will be through
+  aggregation in `Content` and `Location` objects.
+* Deprecates ContentInfo Pagerfanta search adapters (to be removed in 3.0):
+  * `ContentInfoSearchAdapter`
+  * `ContentInfoSearchHitAdapter`
+
 2.1.1 (07.09.2017)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@
   - [`Field`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/Field.php)
   - [`Location`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/Location.php)
 
+## Installation
+
+To install Site API simple add it as a dependency to your project:
+
+```sh
+composer require netgen/ezplatform-site-api:^2.2
+```
+
+That will provide you with public Site API services defined in the [container](lib/Resources/config/services.yml),
+which will enable you to rewrite your custom services piece by piece, while at the same time controllers
+and Twig templates can keep using the old code (meaning eZ Platform Repository API).
+
+If you are starting from scratch, or once you're ready to fully switch to Site API, you can set it
+as a default for URL alias routes with the following site-access aware config:
+
+```yml
+netgen_ez_platform_site_api:
+    system:
+        frontend_group:
+            override_url_alias_view_action: true
+```
+
+For more details see [Usage instructions](USAGE.md).
+
 ## Detailed usage instructions
 
 The following document details what needs to be done to rewrite your existing site to Site API:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ composer require netgen/ezplatform-site-api:^2.2
 ```
 
 That will provide you with public Site API services defined in the [container](lib/Resources/config/services.yml),
-which will enable you to rewrite your custom services piece by piece, while at the same time controllers
+which will enable you to rewrite your custom services piece by piece. At the same time controllers
 and Twig templates can keep using the old code (meaning eZ Platform Repository API).
 
 If you are starting from scratch, or once you're ready to fully switch to Site API, you can set it

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - New set of aggregate objects, tailored to make building websites easier
 
   - [`Content`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/Content.php)
+  - [`ContentInfo`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/ContentInfo.php)
   - [`Field`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/Field.php)
   - [`Location`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/Location.php)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 - New set of aggregate objects, tailored to make building websites easier
 
   - [`Content`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/Content.php)
-  - [`ContentInfo`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/ContentInfo.php)
   - [`Field`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/Field.php)
   - [`Location`](https://github.com/netgen/ezplatform-site-api/blob/master/lib/API/Values/Location.php)
 
@@ -54,14 +53,14 @@ The following document details what needs to be done to rewrite your existing si
       // ...
   }
 
-  echo $location->parent->contentInfo->name;
+  echo $location->parent->content->name;
   ```
 
   ```php
   /** @var \Netgen\EzPlatformSiteApi\API\Site $site */
   $loadService = $site->getLoadService();
   $content = $loadService->loadContent(24);
-  $contentInfo = $loadService->loadContentInfo(12);
+  $location = $loadService->loadLocation(12);
 
   foreach ($content->locations as $location) {
       // ...
@@ -71,7 +70,7 @@ The following document details what needs to be done to rewrite your existing si
       // ...
   }
 
-  if (!$contentInfo->content->getField('image')->isEmpty()) {
+  if (!$location->content->getField('image')->isEmpty()) {
       // ...
   }
   ```
@@ -107,7 +106,7 @@ The following document details what needs to be done to rewrite your existing si
 - Twig
 
   ```twig
-  <h1>{{ content.name }} [{{ content.contentInfo.contentTypeIdentifier }}]</h1>
+  <h1>{{ content.name }} [{{ content.contentTypeIdentifier }}]</h1>
 
   {% for identifier, field in content.fields %}
       <h4>Field '{{ identifier }}' in Content #{{ field.content.id }}</h4>
@@ -125,7 +124,7 @@ The following document details what needs to be done to rewrite your existing si
   ```twig
   {% set children = location.filterChildren(['blog_post'], 10, 2) %}
 
-  <p>Parent name: {{ location.parent.contentInfo.name }}<p>
+  <p>Parent name: {{ location.parent.content.name }}<p>
 
   <!-- 'children' variable is full Pagerfanta instance -->
   <p>Total blog posts: {{ children.nbResults }}</p>
@@ -134,7 +133,7 @@ The following document details what needs to be done to rewrite your existing si
 
   <ul>
   {% for child in children %}
-      <li>{{ child.contentInfo.name }}</li>
+      <li>{{ child.content.name }}</li>
   {% endfor %}
   </ul>
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Installation
 
-To install Site API simple add it as a dependency to your project:
+To install Site API simply add it as a dependency to your project:
 
 ```sh
 composer require netgen/ezplatform-site-api:^2.2


### PR DESCRIPTION
* Introduces lazy loading of `Content` fields, meaning that fields will be transparently loaded only
if accessed
* Introduces lazy loading of `ContentInfo` when accessed from `Content` or `Location`
* Deprecates all methods to obtain `ContentInfo` object (to be removed in 3.0):
  * `LoadService::loadContentInfo()`
  * `LoadService::loadContentInfoByRemoteId()`
  * `FilterService::filterContentInfo()`
  * `FindService::findContentInfo()`

  Note that `ContentInfo` itself is not deprecated, for the sole reason of keeping Site API in line
  with Repository API. With 3.0, the only way to access `ContentInfo` object will be through
  aggregation in `Content` and `Location` objects.
* Deprecates ContentInfo Pagerfanta search adapters (to be removed in 3.0):
  * `ContentInfoSearchAdapter`
  * `ContentInfoSearchHitAdapter`
* Fixes https://github.com/netgen/ezplatform-site-api/issues/48: Mapping a field takes the wrong ID

### To do
- [x] finalize release