### PR TITLE
Fix mapping a field with wrong ID 

### DIFF
--- a/lib/Core/Site/DomainObjectMapper.php
+++ b/lib/Core/Site/DomainObjectMapper.php
@@ -176,7 +176,7 @@ final class DomainObjectMapper
         );
 
         return new Field([
-            'id' => $fieldDefinition->id,
+            'id' => $apiField->id,
             'fieldDefIdentifier' => $fieldDefinition->identifier,
             'value' => $apiField->value,
             'languageCode' => $apiField->languageCode,

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -668,6 +668,7 @@ class BaseTest extends APIBaseTest
     {
         $field = $content->getField($identifier);
 
+        $this->assertSame($field->id, $field->innerField->id);
         $this->assertSame($data['isEmpty'], $field->isEmpty());
         $this->assertSame($identifier, $field->fieldDefIdentifier);
         $this->assertSame($data['fieldTypeIdentifier'], $field->fieldTypeIdentifier);


### PR DESCRIPTION
This PR fixes https://github.com/netgen/ezplatform-site-api/issues/48

In `master` branch, mapping a Site API field object takes the wrong ID. The mapper uses field definition ID instead of the field ID.

https://github.com/netgen/ezplatform-site-api/blob/master/lib/Core/Site/DomainObjectMapper.php#L179-L180

TODO:
- [x] Add test
- [x] Fix