### PR TITLE
Introduce __debugInfo for cleaner dump

### DIFF
--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -283,4 +283,21 @@ final class Content extends APIContent
 
         return $this->contentInfo;
     }
+
+    public function __debugInfo()
+    {
+        $this->initializeFields();
+
+        return [
+            'id' => $this->id,
+            'mainLocationId' => $this->mainLocationId,
+            'name' => $this->name,
+            'languageCode' => $this->languageCode,
+            'contentInfo' => $this->getContentInfo(),
+            'fields' => $this->fields,
+            //'mainLocation' => $this->getMainLocation(),
+            //'innerContent' => $this->getInnerContent(),
+            //'innerVersionInfo' => $this->innerVersionInfo,
+        ];
+    }
 }

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -174,4 +174,31 @@ final class ContentInfo extends APIContentInfo
 
         return $this->internalMainLocation;
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'id' => $this->innerContentInfo->id,
+            'contentTypeId' => $this->innerContentInfo->contentTypeId,
+            'sectionId' => $this->innerContentInfo->sectionId,
+            'currentVersionNo' => $this->innerContentInfo->currentVersionNo,
+            'published' => $this->innerContentInfo->published,
+            'ownerId' => $this->innerContentInfo->ownerId,
+            'modificationDate' => $this->innerContentInfo->modificationDate,
+            'publishedDate' => $this->innerContentInfo->publishedDate,
+            'alwaysAvailable' => $this->innerContentInfo->alwaysAvailable,
+            'remoteId' => $this->innerContentInfo->remoteId,
+            'mainLanguageCode' => $this->innerContentInfo->mainLanguageCode,
+            'mainLocationId' => $this->innerContentInfo->mainLocationId,
+            'name' => $this->name,
+            'languageCode' => $this->languageCode,
+            'contentTypeIdentifier' => $this->contentTypeIdentifier,
+            'contentTypeName' => $this->contentTypeName,
+            'contentTypeDescription' => $this->contentTypeDescription,
+            //'innerContentInfo' => $this->innerContentInfo,
+            //'innerContentType' => $this->innerContentType,
+            //'mainLocation' => $this->getMainLocation(),
+            //'content' => $this->getContent(),
+        ];
+    }
 }

--- a/lib/Core/Site/Values/Field.php
+++ b/lib/Core/Site/Values/Field.php
@@ -76,4 +76,21 @@ final class Field extends APIField
     {
         return $this->isEmpty;
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'id' => $this->id,
+            'fieldDefIdentifier' => $this->fieldDefIdentifier,
+            'value' => $this->value,
+            'languageCode' => $this->languageCode,
+            'fieldTypeIdentifier' => $this->fieldTypeIdentifier,
+            'name' => $this->name,
+            'description' => $this->description,
+            //'content' => $this->content,
+            'contentId' => $this->content->id,
+            //'innerField' => $this->innerField,
+            'innerFieldDefinition' => $this->innerFieldDefinition,
+        ];
+    }
 }

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -286,4 +286,27 @@ final class Location extends APILocation
 
         return [$sortClause];
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'id' => $this->innerLocation->id,
+            'status' => $this->innerLocation->status,
+            'priority' => $this->innerLocation->priority,
+            'hidden' => $this->innerLocation->hidden,
+            'invisible' => $this->innerLocation->invisible,
+            'remoteId' => $this->innerLocation->remoteId,
+            'parentLocationId' => $this->innerLocation->parentLocationId,
+            'pathString' => $this->innerLocation->pathString,
+            'path' => $this->innerLocation->path,
+            'depth' => $this->innerLocation->depth,
+            'sortField' => $this->innerLocation->sortField,
+            'sortOrder' => $this->innerLocation->sortOrder,
+            'contentId' => $this->innerLocation->contentId,
+            //'innerLocation' => $this->innerLocation,
+            'contentInfo' => $this->getContentInfo(),
+            //'parent' => $this->getParent(),
+            //'content' => $this->getContent(),
+        ];
+    }
 }


### PR DESCRIPTION
This introduces [__debugInfo()](http://php.net/manual/en/language.oop5.magic.php#object.debuginfo) on the domain objects, in order to have saner output when dumping them for debugging.

This is to avoid dumping aggregated services, but also some of the properties are omitted to avoid recursion and tree traversal (`$location->parent->parent...`, `$content->mainLocation->content...` etc). Some other properties (most of `inner*` bunch) are also omitted as it seems to me they usually won't be of interest, so would end up adding noise.

Skipped properties are commented out for the purpose of review.

Note: `__debugInfo()` is available only with PHP >=5.6.