### PR TITLE
Introduce $owner and $innerOwnerUser Content properties

### DIFF
--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -18,6 +18,8 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\ContentInfo $contentInfo
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Field[] $fields
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location|null $mainLocation
+ * @property-read \Netgen\EzPlatformSiteApi\API\Values\Content $owner
+ * @property-read \eZ\Publish\API\Repository\Values\User\User $innerOwnerUser
  * @property-read \eZ\Publish\API\Repository\Values\Content\Content $innerContent
  * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $innerVersionInfo
  * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo

--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -18,8 +18,8 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\ContentInfo $contentInfo
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Field[] $fields
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location|null $mainLocation
- * @property-read \Netgen\EzPlatformSiteApi\API\Values\Content $owner
- * @property-read \eZ\Publish\API\Repository\Values\User\User $innerOwnerUser
+ * @property-read \Netgen\EzPlatformSiteApi\API\Values\Content|null $owner
+ * @property-read \eZ\Publish\API\Repository\Values\User\User|null $innerOwnerUser
  * @property-read \eZ\Publish\API\Repository\Values\Content\Content $innerContent
  * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $innerVersionInfo
  * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo

--- a/lib/Core/Site/DomainObjectMapper.php
+++ b/lib/Core/Site/DomainObjectMapper.php
@@ -5,6 +5,7 @@ namespace Netgen\EzPlatformSiteApi\Core\Site;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\API\Repository\Values\Content\Field as APIField;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
@@ -46,21 +47,29 @@ final class DomainObjectMapper
     private $contentService;
 
     /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    private $userService;
+
+    /**
      * @param \Netgen\EzPlatformSiteApi\API\Site $site
      * @param \eZ\Publish\API\Repository\ContentService $contentService
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \eZ\Publish\API\Repository\FieldTypeService $fieldTypeService
+     * @param \eZ\Publish\API\Repository\UserService $userService
      */
     public function __construct(
         SiteInterface $site,
         ContentService $contentService,
         ContentTypeService $contentTypeService,
-        FieldTypeService $fieldTypeService
+        FieldTypeService $fieldTypeService,
+        UserService $userService
     ) {
         $this->site = $site;
         $this->contentService = $contentService;
         $this->contentTypeService = $contentTypeService;
         $this->fieldTypeService = $fieldTypeService;
+        $this->userService = $userService;
     }
 
     /**
@@ -85,6 +94,7 @@ final class DomainObjectMapper
                 'site' => $this->site,
                 'domainObjectMapper' => $this,
                 'contentService' => $this->contentService,
+                'userService' => $this->userService,
             ]
         );
     }

--- a/lib/Core/Site/Site.php
+++ b/lib/Core/Site/Site.php
@@ -7,6 +7,7 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\FieldTypeService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\UserService;
 use Netgen\EzPlatformSiteApi\API\Settings as BaseSite;
 use Netgen\EzPlatformSiteApi\API\Site as SiteInterface;
 
@@ -53,6 +54,11 @@ class Site implements SiteInterface
     private $filteringSearchService;
 
     /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    private $userService;
+
+    /**
      * @var \Netgen\EzPlatformSiteApi\API\FilterService
      */
     private $filterService;
@@ -75,6 +81,7 @@ class Site implements SiteInterface
      * @param \eZ\Publish\API\Repository\LocationService $locationService
      * @param \eZ\Publish\API\Repository\SearchService $searchService
      * @param \eZ\Publish\API\Repository\SearchService $filteringSearchService
+     * @param \eZ\Publish\API\Repository\UserService $userService
      */
     public function __construct(
         BaseSite $settings,
@@ -83,7 +90,8 @@ class Site implements SiteInterface
         FieldTypeService $fieldTypeService,
         LocationService $locationService,
         SearchService $searchService,
-        SearchService $filteringSearchService
+        SearchService $filteringSearchService,
+        UserService $userService
     ) {
         $this->settings = $settings;
         $this->contentService = $contentService;
@@ -92,6 +100,7 @@ class Site implements SiteInterface
         $this->locationService = $locationService;
         $this->searchService = $searchService;
         $this->filteringSearchService = $filteringSearchService;
+        $this->userService = $userService;
     }
 
     public function getSettings()
@@ -151,7 +160,8 @@ class Site implements SiteInterface
                 $this,
                 $this->contentService,
                 $this->contentTypeService,
-                $this->fieldTypeService
+                $this->fieldTypeService,
+                $this->userService
             );
         }
 

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -332,7 +332,7 @@ final class Content extends APIContent
         }
 
         try {
-            $this->owner = $this->site->getLoadService()->loadContent($this->contentInfo->ownerId);
+            $this->owner = $this->site->getLoadService()->loadContent($this->getContentInfo()->ownerId);
         } catch (NotFoundException $e) {
             // Do nothing
         }
@@ -352,7 +352,7 @@ final class Content extends APIContent
         }
 
         try {
-            $this->innerOwnerUser = $this->userService->loadUser($this->contentInfo->ownerId);
+            $this->innerOwnerUser = $this->userService->loadUser($this->getContentInfo()->ownerId);
         } catch (NotFoundException $e) {
             // Do nothing
         }

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -98,6 +98,20 @@ final class Content extends APIContent
      */
     private $internalMainLocation;
 
+    /**
+     * Denotes if $owner property is initialized.
+     *
+     * @var bool
+     */
+    private $isOwnerInitialized = false;
+
+    /**
+     * Denotes if $innerOwnerUser property is initialized.
+     *
+     * @var bool
+     */
+    private $isInnerOwnerUserInitialized = false;
+
     public function __construct(array $properties = [])
     {
         $this->site = $properties['site'];
@@ -313,17 +327,17 @@ final class Content extends APIContent
      */
     private function getOwner()
     {
-        if ($this->owner === null) {
-            try {
-                $this->owner = $this->site->getLoadService()->loadContent($this->contentInfo->ownerId);
-            } catch (NotFoundException $e) {
-                $this->owner = false;
-            }
+        if ($this->isOwnerInitialized) {
+            return $this->owner;
         }
 
-        if ($this->owner === false) {
-            return null;
+        try {
+            $this->owner = $this->site->getLoadService()->loadContent($this->contentInfo->ownerId);
+        } catch (NotFoundException $e) {
+            // Do nothing
         }
+
+        $this->isOwnerInitialized = true;
 
         return $this->owner;
     }
@@ -333,17 +347,17 @@ final class Content extends APIContent
      */
     private function getInnerOwnerUser()
     {
-        if ($this->innerOwnerUser === null) {
-            try {
-                $this->innerOwnerUser = $this->userService->loadUser($this->contentInfo->ownerId);
-            } catch (NotFoundException $e) {
-                $this->innerOwnerUser = false;
-            }
+        if ($this->isInnerOwnerUserInitialized) {
+            return $this->innerOwnerUser;
         }
 
-        if ($this->innerOwnerUser === false) {
-            return null;
+        try {
+            $this->innerOwnerUser = $this->userService->loadUser($this->contentInfo->ownerId);
+        } catch (NotFoundException $e) {
+            // Do nothing
         }
+
+        $this->isInnerOwnerUserInitialized = true;
 
         return $this->innerOwnerUser;
     }

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -41,6 +41,7 @@ services:
             - '@ezpublish.api.service.location'
             - '@ezpublish.api.service.search'
             - '@netgen.ezplatform_site.repository.filtering_search_service'
+            - '@ezpublish.api.service.user'
         lazy: true
 
     netgen.ezplatform_site.core.filter_service:

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -569,6 +569,8 @@ class BaseTest extends APIBaseTest
         $this->assertEquals($data['languageCode'], $content->languageCode);
         $this->assertContentInfo($content->contentInfo, $data);
         $this->assertFields($content, $data);
+        $this->assertInstanceOf('\Netgen\EzPlatformSiteApi\API\Values\Content', $content->owner);
+        $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\User\User', $content->innerOwnerUser);
         $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Content', $content->innerContent);
         $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\VersionInfo', $content->versionInfo);
         $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\VersionInfo', $content->innerVersionInfo);

--- a/tests/lib/Integration/SetupFactory/Legacy.php
+++ b/tests/lib/Integration/SetupFactory/Legacy.php
@@ -15,9 +15,8 @@ class Legacy extends CoreLegacySetupFactory
 {
     public function getServiceContainer()
     {
-        if (!isset(self::$serviceContainer)) {
-            $configPath = __DIR__ . '/../../../../vendor/ezsystems/ezpublish-kernel/config.php';
-            $config = include $configPath;
+        if (null === self::$serviceContainer) {
+            $config = include __DIR__ . '/../../../../vendor/ezsystems/ezpublish-kernel/config.php';
             $installDir = $config['install_dir'];
             /* @var \Symfony\Component\DependencyInjection\ContainerBuilder $containerBuilder */
             $containerBuilder = include $config['container_builder_path'];

--- a/tests/lib/Integration/SetupFactory/Legacy.php
+++ b/tests/lib/Integration/SetupFactory/Legacy.php
@@ -13,14 +13,6 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  */
 class Legacy extends CoreLegacySetupFactory
 {
-    public function getRepository($initializeFromScratch = true)
-    {
-        // Load repository first so all initialization steps are done
-        $repository = parent::getRepository($initializeFromScratch);
-
-        return $repository;
-    }
-
     public function getServiceContainer()
     {
         if (!isset(self::$serviceContainer)) {

--- a/tests/lib/Unit/Core/Site/Values/ContentTest.php
+++ b/tests/lib/Unit/Core/Site/Values/ContentTest.php
@@ -307,7 +307,9 @@ class ContentTest extends TestCase
             ->expects($this->any())
             ->method('loadContentType')
             ->with('contentTypeId')
-            ->willReturn(new ContentType());
+            ->willReturn(new ContentType([
+                'fieldDefinitions' => [],
+            ]));
 
         return $this->contentTypeServiceMock;
     }

--- a/tests/lib/Unit/Core/Site/Values/ContentTest.php
+++ b/tests/lib/Unit/Core/Site/Values/ContentTest.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Tests\Unit\Core\Site\Values;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo as RepoContentInfo;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use Netgen\EzPlatformSiteApi\API\LoadService;
+use Netgen\EzPlatformSiteApi\API\Site;
+use Netgen\EzPlatformSiteApi\API\Values\Content as APIContent;
+use Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper;
+use Netgen\EzPlatformSiteApi\Core\Site\Values\Content;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Content value unit tests.
+ *
+ * @see \Netgen\EzPlatformSiteApi\API\Values\Content
+ */
+class ContentTest extends TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Netgen\EzPlatformSiteApi\API\Site
+     */
+    protected $siteMock;
+
+    /**
+     * @var \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper
+     */
+    protected $domainObjectMapper;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\ContentService
+     */
+    protected $contentServiceMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\ContentTypeService
+     */
+    protected $contentTypeServiceMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\FieldTypeService
+     */
+    protected $fieldTypeServiceMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Netgen\EzPlatformSiteApi\API\LoadService
+     */
+    protected $loadServiceMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\UserService
+     */
+    protected $userServiceMock;
+
+    public function setUp()
+    {
+        $this->getSiteMock();
+        $this->getDomainObjectMapper();
+        $this->getLoadServiceMock();
+        $this->getUserServiceMock();
+
+        parent::setUp();
+    }
+
+    public function testContentOwnerExists()
+    {
+        $content = $this->getMockedContent();
+        $ownerMock = $this->getMockBuilder(APIContent::class)->getMock();
+
+        $this
+            ->loadServiceMock
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with('ownerId')
+            ->willReturn($ownerMock);
+
+        $this->assertSame($ownerMock, $content->owner);
+    }
+
+    public function testContentOwnerExistsRepeated()
+    {
+        $content = $this->getMockedContent();
+        $ownerMock = $this->getMockBuilder(APIContent::class)->getMock();
+
+        $this
+            ->loadServiceMock
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with('ownerId')
+            ->willReturn($ownerMock);
+
+        $this->assertSame($ownerMock, $content->owner);
+        $this->assertSame($ownerMock, $content->owner);
+    }
+
+    public function testContentOwnerDoesNotExist()
+    {
+        $content = $this->getMockedContent();
+
+        $this
+            ->loadServiceMock
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with('ownerId')
+            ->willThrowException(
+                new NotFoundException('ContentType', 'contentTypeId')
+            );
+
+        $this->assertNull($content->owner);
+    }
+
+    public function testContentOwnerDoesNotExistRepeated()
+    {
+        $content = $this->getMockedContent();
+
+        $this
+            ->loadServiceMock
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with('ownerId')
+            ->willThrowException(
+                new NotFoundException('ContentType', 'contentTypeId')
+            );
+
+        $this->assertNull($content->owner);
+        $this->assertNull($content->owner);
+    }
+
+    public function testContentInnerOwnerUserExists()
+    {
+        $content = $this->getMockedContent();
+        $ownerUserMock = $this->getMockBuilder(User::class)->getMock();
+
+        $this
+            ->userServiceMock
+            ->expects($this->once())
+            ->method('loadUser')
+            ->with('ownerId')
+            ->willReturn($ownerUserMock);
+
+        $this->assertSame($ownerUserMock, $content->innerOwnerUser);
+    }
+
+    public function testContentInnerOwnerUserExistsRepeated()
+    {
+        $content = $this->getMockedContent();
+        $ownerUserMock = $this->getMockBuilder(User::class)->getMock();
+
+        $this
+            ->userServiceMock
+            ->expects($this->once())
+            ->method('loadUser')
+            ->with('ownerId')
+            ->willReturn($ownerUserMock);
+
+        $this->assertSame($ownerUserMock, $content->innerOwnerUser);
+        $this->assertSame($ownerUserMock, $content->innerOwnerUser);
+    }
+
+    public function testContentInnerOwnerUserDoesNotExist()
+    {
+        $content = $this->getMockedContent();
+
+        $this
+            ->userServiceMock
+            ->expects($this->once())
+            ->method('loadUser')
+            ->with('ownerId')
+            ->willThrowException(
+                new NotFoundException('User', 'ownerId')
+            );
+
+        $this->assertNull($content->innerOwnerUser);
+    }
+
+    public function testContentInnerOwnerUserDoesNotExistRepeated()
+    {
+        $content = $this->getMockedContent();
+
+        $this
+            ->userServiceMock
+            ->expects($this->once())
+            ->method('loadUser')
+            ->with('ownerId')
+            ->willThrowException(
+                new NotFoundException('User', 'ownerId')
+            );
+
+        $this->assertNull($content->innerOwnerUser);
+        $this->assertNull($content->innerOwnerUser);
+    }
+
+    /**
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content
+     */
+    protected function getMockedContent()
+    {
+        return new Content([
+            'site' => $this->getSiteMock(),
+            'domainObjectMapper' => $this->getDomainObjectMapper(),
+            'contentService' => $this->getContentServiceMock(),
+            'userService' => $this->getUserServiceMock(),
+            'innerVersionInfo' => new VersionInfo([
+                'contentInfo' => new RepoContentInfo([
+                    'ownerId' => 'ownerId',
+                    'contentTypeId' => 'contentTypeId',
+                ])
+            ]),
+        ]);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Netgen\EzPlatformSiteApi\API\Site
+     */
+    protected function getSiteMock()
+    {
+        if (null !== $this->siteMock) {
+            return $this->siteMock;
+        }
+
+        $this->siteMock = $this
+            ->getMockBuilder(Site::class)
+            ->getMock();
+
+        $this->siteMock
+            ->expects($this->any())
+            ->method('getLoadService')
+            ->willReturn($this->getLoadServiceMock());
+
+        return $this->siteMock;
+    }
+
+    /**
+     * @return \Netgen\EzPlatformSiteApi\Core\Site\DomainObjectMapper
+     */
+    protected function getDomainObjectMapper()
+    {
+        if (null !== $this->domainObjectMapper) {
+            return $this->domainObjectMapper;
+        }
+
+        $this->domainObjectMapper = new DomainObjectMapper(
+            $this->getSiteMock(),
+            $this->getContentServiceMock(),
+            $this->getContentTypeServiceMock(),
+            $this->getFieldTypeServiceMock(),
+            $this->getUserServiceMock()
+        );
+
+        return $this->domainObjectMapper;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Netgen\EzPlatformSiteApi\API\LoadService
+     */
+    protected function getLoadServiceMock()
+    {
+        if (null !== $this->loadServiceMock) {
+            return $this->loadServiceMock;
+        }
+
+        $this->loadServiceMock = $this
+            ->getMockBuilder(LoadService::class)
+            ->getMock();
+
+        return $this->loadServiceMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\ContentService
+     */
+    protected function getContentServiceMock()
+    {
+        if (null !== $this->contentServiceMock) {
+            return $this->contentServiceMock;
+        }
+
+        $this->contentServiceMock = $this
+            ->getMockBuilder(ContentService::class)
+            ->getMock();
+
+        return $this->contentServiceMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\ContentTypeService
+     */
+    protected function getContentTypeServiceMock()
+    {
+        if (null !== $this->contentTypeServiceMock) {
+            return $this->contentTypeServiceMock;
+        }
+
+        $this->contentTypeServiceMock = $this
+            ->getMockBuilder(ContentTypeService::class)
+            ->getMock();
+
+        $this->contentTypeServiceMock
+            ->expects($this->any())
+            ->method('loadContentType')
+            ->with('contentTypeId')
+            ->willReturn(new ContentType());
+
+        return $this->contentTypeServiceMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\FieldTypeService
+     */
+    protected function getFieldTypeServiceMock()
+    {
+        if (null !== $this->fieldTypeServiceMock) {
+            return $this->fieldTypeServiceMock;
+        }
+
+        $this->fieldTypeServiceMock = $this
+            ->getMockBuilder(FieldTypeService::class)
+            ->getMock();
+
+        return $this->fieldTypeServiceMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\UserService
+     */
+    protected function getUserServiceMock()
+    {
+        if (null !== $this->userServiceMock) {
+            return $this->userServiceMock;
+        }
+
+        $this->userServiceMock = $this
+            ->getMockBuilder(UserService::class)
+            ->getMock();
+
+        return $this->userServiceMock;
+    }
+}


### PR DESCRIPTION
This adds new lazy-loaded properties to `Content` object:

- `$owner`, instance of `\Netgen\EzPlatformSiteApi\API\Values\Content`
- `$innerOwnerUser`, instance of `\eZ\Publish\API\Repository\Values\User\User`

Since we can't be sure that Content's owner actually exists, `NotFoundException` is intercepted to return `null`.

### TODOs
- [x] add tests
- [x] handle `__debugInfo()` from #50 
- [x] properly hint that value can be `null`