### PR TITLE
Allow installing on eZ kernel 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "~5.5|~7.0",
-        "ezsystems/ezpublish-kernel": "^6.0"
+        "ezsystems/ezpublish-kernel": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.7"


### PR DESCRIPTION
Since eZ kernel 7.0 is now in beta, would be good to have it in 2.3 :)