### PR TITLE
Fix building repository after implementing tolerant search service

### DIFF
--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -13,6 +13,7 @@ services:
         arguments:
             - '@ezpublish.api.persistence_handler'
             - '@ezpublish.spi.search.legacy'
+            - '@?ezpublish.search.background_indexer'
         lazy: true
         public: false
 


### PR DESCRIPTION
https://github.com/ezsystems/ezpublish-kernel/pull/2142 added a new param to `RepositoryFactory::buildRepository`.

This adds the param as an optional dependency (hence `?`) so it doesn't crash on previous versions if service doesn't exist.