### PR TITLE
Add adapters from filter and find services to eZ search service

### DIFF
--- a/lib/API/Adapter/FilterServiceAdapter.php
+++ b/lib/API/Adapter/FilterServiceAdapter.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\API\Adapter;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\SPI\Search\Capable;
+use eZ\Publish\SPI\Search\Handler;
+use Netgen\EzPlatformSiteApi\API\FilterService;
+
+/**
+ * This class is an adapter from Site API filter service to SearchService interface
+ * from eZ Publish kernel. The point is being able to replace usage of eZ search service
+ * with Site API filter service without touching consuming code.
+ *
+ * Methods implemented here do not use $languageFilter argument since it is handled automatically
+ * by the filter service itself.
+ *
+ * As for $filterOnUserPermissions, filter service doesn't support it, so it is simply ignored.
+ */
+final class FilterServiceAdapter implements SearchService
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FilterService
+     */
+    private $filterService;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Handler
+     */
+    private $searchHandler;
+
+    public function __construct(FilterService $filterService, Handler $searchHandler)
+    {
+        $this->filterService = $filterService;
+        $this->searchHandler = $searchHandler;
+    }
+
+    public function findContent(Query $query, array $languageFilter = [], $filterOnUserPermissions = true)
+    {
+        $searchResult = $this->filterService->filterContent($query);
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $searchHit->valueObject = $searchHit->valueObject->innerContent;
+        }
+
+        return $searchResult;
+    }
+
+    public function findContentInfo(Query $query, array $languageFilter = [], $filterOnUserPermissions = true)
+    {
+        $searchResult = $this->filterService->filterContent($query);
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $searchHit->valueObject = $searchHit->valueObject->innerContentInfo;
+        }
+
+        return $searchResult;
+    }
+
+    public function findLocations(LocationQuery $query, array $languageFilter = [], $filterOnUserPermissions = true)
+    {
+        $searchResult = $this->filterService->filterLocations($query);
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $searchHit->valueObject = $searchHit->valueObject->innerLocation;
+        }
+
+        return $searchResult;
+    }
+
+    public function findSingle(Criterion $filter, array $languageFilter = [], $filterOnUserPermissions = true)
+    {
+        $query = new Query();
+        $query->filter = $filter;
+        $query->limit = 1;
+
+        $searchResult = $this->filterService->filterContent($query);
+
+        if (!$searchResult->totalCount) {
+            throw new NotFoundException('Content', 'findSingle() found no content for given $filter');
+        } elseif ($searchResult->totalCount > 1) {
+            throw new InvalidArgumentException('totalCount', 'findSingle() found more then one item for given $filter');
+        }
+
+        return $searchResult->searchHits[0]->valueObject->innerContent;
+    }
+
+    public function suggest($prefix, $fieldPaths = [], $limit = 10, Criterion $filter = null)
+    {
+    }
+
+    public function supports($capabilityFlag)
+    {
+        if ($this->searchHandler instanceof Capable) {
+            return $this->searchHandler->supports($capabilityFlag);
+        }
+
+        return false;
+    }
+}

--- a/lib/API/Adapter/FindServiceAdapter.php
+++ b/lib/API/Adapter/FindServiceAdapter.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\API\Adapter;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\SPI\Search\Capable;
+use eZ\Publish\SPI\Search\Handler;
+use Netgen\EzPlatformSiteApi\API\FindService;
+
+/**
+ * This class is an adapter from Site API find service to SearchService interface
+ * from eZ Publish kernel. The point is being able to replace usage of eZ search service
+ * with Site API find service without touching consuming code.
+ *
+ * Methods implemented here do not use $languageFilter argument since it is handled automatically
+ * by the find service itself.
+ *
+ * As for $filterOnUserPermissions, find service doesn't support it, so it is simply ignored.
+ */
+final class FindServiceAdapter implements SearchService
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FindService
+     */
+    private $findService;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Handler
+     */
+    private $searchHandler;
+
+    public function __construct(FindService $findService, Handler $searchHandler)
+    {
+        $this->findService = $findService;
+        $this->searchHandler = $searchHandler;
+    }
+
+    public function findContent(Query $query, array $languageFilter = [], $filterOnUserPermissions = true)
+    {
+        $searchResult = $this->findService->findContent($query);
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $searchHit->valueObject = $searchHit->valueObject->innerContent;
+        }
+
+        return $searchResult;
+    }
+
+    public function findContentInfo(Query $query, array $languageFilter = [], $filterOnUserPermissions = true)
+    {
+        $searchResult = $this->findService->findContent($query);
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $searchHit->valueObject = $searchHit->valueObject->innerContentInfo;
+        }
+
+        return $searchResult;
+    }
+
+    public function findLocations(LocationQuery $query, array $languageFilter = [], $filterOnUserPermissions = true)
+    {
+        $searchResult = $this->findService->findLocations($query);
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $searchHit->valueObject = $searchHit->valueObject->innerLocation;
+        }
+
+        return $searchResult;
+    }
+
+    public function findSingle(Criterion $filter, array $languageFilter = [], $filterOnUserPermissions = true)
+    {
+        $query = new Query();
+        $query->filter = $filter;
+        $query->limit = 1;
+
+        $searchResult = $this->findService->findContent($query);
+
+        if (!$searchResult->totalCount) {
+            throw new NotFoundException('Content', 'findSingle() found no content for given $filter');
+        } elseif ($searchResult->totalCount > 1) {
+            throw new InvalidArgumentException('totalCount', 'findSingle() found more then one item for given $filter');
+        }
+
+        return $searchResult->searchHits[0]->valueObject->innerContent;
+    }
+
+    public function suggest($prefix, $fieldPaths = [], $limit = 10, Criterion $filter = null)
+    {
+    }
+
+    public function supports($capabilityFlag)
+    {
+        if ($this->searchHandler instanceof Capable) {
+            return $this->searchHandler->supports($capabilityFlag);
+        }
+
+        return false;
+    }
+}

--- a/lib/Resources/config/services.yml
+++ b/lib/Resources/config/services.yml
@@ -18,3 +18,21 @@ services:
 
     netgen.ezplatform_site.site:
         alias: 'netgen.ezplatform_site.core.site'
+
+    # Search adapters for filter and find services to
+    # eZ\Publish\API\Repository\SearchService interface
+    # from eZ Publish
+
+    netgen.ezplatform_site.filter_service.search_adapter:
+        class: Netgen\EzPlatformSiteApi\API\Adapter\FilterServiceAdapter
+        public: false
+        arguments:
+            - "@netgen.ezplatform_site.filter_service"
+            - "@ezpublish.spi.search.legacy"
+
+    netgen.ezplatform_site.find_service.search_adapter:
+        class: Netgen\EzPlatformSiteApi\API\Adapter\FindServiceAdapter
+        public: false
+        arguments:
+            - "@netgen.ezplatform_site.find_service"
+            - "@ezpublish.spi.search_engine"


### PR DESCRIPTION
These classes are adapters from Site API filter and find services to SearchService interface
from eZ Publish kernel. The point is being able to replace usage of eZ search service
with Site API filter or find service without touching consuming code.

Ofcourse, we need to convert value objects in search hits from Site API to eZ API value objects.

Methods implemented here do not use `$languageFilter` argument since it is handled automatically
by the filter and find services themselves.

As for `$filterOnUserPermissions`, filter and find services don't support it, so it is simply ignored.

Ran some basic tests with replaced services, and it works fine.