### PR TITLE
[3.0] Implement Twig runtimes and use Twig namespaces

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -34,11 +34,18 @@ services:
     netgen.ezplatform_site.twig.extension.field_rendering:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\FieldRenderingExtension
         public: false
+        tags:
+            - {name: twig.extension}
+
+    netgen.ezplatform_site.twig.runtime.field_rendering:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\FieldRenderingRuntime
+        # public: false
         arguments:
+            - '@twig'
             - '@ezpublish.templating.field_block_renderer'
             - '@ezpublish.fieldType.parameterProviderRegistry'
         tags:
-            - { name: twig.extension }
+            - {name: twig.runtime}
 
     netgen.ezplatform_site.sort_clause_parser:
         class: Netgen\EzPlatformSiteApi\Core\Site\QueryType\SortClauseParser
@@ -47,9 +54,16 @@ services:
     netgen.ezplatform_site.twig.extension.image:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageExtension
         public: false
-        arguments: ['@ezpublish.fieldType.ezimage.variation_service']
         tags:
             - { name: twig.extension }
+
+    netgen.ezplatform_site.twig.runtime.image:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageRuntime
+        # public: false
+        arguments:
+            - '@ezpublish.fieldType.ezimage.variation_service'
+        tags:
+            - { name: twig.runtime }
 
     netgen.ezplatform_site.query_type.parameter_processor:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: services/templating.yml }
+
 parameters:
     # Template defaults for standard eZ Platform installation
     # By default we don't override URL alias view action, for that reason these are commented out
@@ -31,39 +34,9 @@ services:
         alias: netgen.ezplatform_site.controller.content.view
         public: true
 
-    netgen.ezplatform_site.twig.extension.field_rendering:
-        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\FieldRenderingExtension
-        public: false
-        tags:
-            - {name: twig.extension}
-
-    netgen.ezplatform_site.twig.runtime.field_rendering:
-        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\FieldRenderingRuntime
-        # public: false
-        arguments:
-            - '@twig'
-            - '@ezpublish.templating.field_block_renderer'
-            - '@ezpublish.fieldType.parameterProviderRegistry'
-        tags:
-            - {name: twig.runtime}
-
     netgen.ezplatform_site.sort_clause_parser:
         class: Netgen\EzPlatformSiteApi\Core\Site\QueryType\SortClauseParser
         public: false
-
-    netgen.ezplatform_site.twig.extension.image:
-        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageExtension
-        public: false
-        tags:
-            - { name: twig.extension }
-
-    netgen.ezplatform_site.twig.runtime.image:
-        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageRuntime
-        # public: false
-        arguments:
-            - '@ezpublish.fieldType.ezimage.variation_service'
-        tags:
-            - { name: twig.runtime }
 
     netgen.ezplatform_site.query_type.parameter_processor:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor
@@ -87,12 +60,4 @@ services:
             - '@ezpublish.query_type.registry'
             - '@netgen.ezplatform_site.filter_service'
             - '@netgen.ezplatform_site.find_service'
-        public: false
-
-    netgen.ezplatform_site.twig.extension.query:
-        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\QueryExtension
-        arguments:
-            - '@netgen.ezplatform_site.query_type.query_executor'
-        tags:
-            - {name: twig.extension}
         public: false

--- a/bundle/Resources/config/services/templating.yml
+++ b/bundle/Resources/config/services/templating.yml
@@ -31,8 +31,14 @@ services:
 
     netgen.ezplatform_site.twig.extension.query:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\QueryExtension
-        arguments:
-            - '@netgen.ezplatform_site.query_type.query_executor'
         tags:
             - { name: twig.extension }
         public: false
+
+    netgen.ezplatform_site.twig.runtime.query:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\QueryRuntime
+        # public: false
+        arguments:
+            - '@netgen.ezplatform_site.query_type.query_executor'
+        tags:
+            - { name: twig.runtime }

--- a/bundle/Resources/config/services/templating.yml
+++ b/bundle/Resources/config/services/templating.yml
@@ -1,0 +1,38 @@
+services:
+    netgen.ezplatform_site.twig.extension.field_rendering:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\FieldRenderingExtension
+        public: false
+        tags:
+            - { name: twig.extension }
+
+    netgen.ezplatform_site.twig.runtime.field_rendering:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\FieldRenderingRuntime
+        # public: false
+        arguments:
+            - '@twig'
+            - '@ezpublish.templating.field_block_renderer'
+            - '@ezpublish.fieldType.parameterProviderRegistry'
+        tags:
+            - {name: twig.runtime}
+
+    netgen.ezplatform_site.twig.extension.image:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageExtension
+        public: false
+        tags:
+            - { name: twig.extension }
+
+    netgen.ezplatform_site.twig.runtime.image:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageRuntime
+        # public: false
+        arguments:
+            - '@ezpublish.fieldType.ezimage.variation_service'
+        tags:
+            - { name: twig.runtime }
+
+    netgen.ezplatform_site.twig.extension.query:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\QueryExtension
+        arguments:
+            - '@netgen.ezplatform_site.query_type.query_executor'
+        tags:
+            - { name: twig.extension }
+        public: false

--- a/bundle/Templating/Twig/Extension/FieldRenderingExtension.php
+++ b/bundle/Templating/Twig/Extension/FieldRenderingExtension.php
@@ -2,126 +2,22 @@
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
 
-use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderRegistryInterface;
-use eZ\Publish\Core\MVC\Symfony\Templating\FieldBlockRendererInterface;
-use Netgen\EzPlatformSiteApi\API\Values\Field;
-use Twig_Environment;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Twig extension for content fields rendering (view).
  */
-class FieldRenderingExtension extends Twig_Extension
+class FieldRenderingExtension extends AbstractExtension
 {
-    /**
-     * @var FieldBlockRendererInterface|\eZ\Publish\Core\MVC\Symfony\Templating\Twig\FieldBlockRenderer
-     */
-    private $fieldBlockRenderer;
-
-    /**
-     * @var ParameterProviderRegistryInterface
-     */
-    private $parameterProviderRegistry;
-
-    public function __construct(
-        FieldBlockRendererInterface $fieldBlockRenderer,
-        ParameterProviderRegistryInterface $parameterProviderRegistry
-    ) {
-        $this->fieldBlockRenderer = $fieldBlockRenderer;
-        $this->parameterProviderRegistry = $parameterProviderRegistry;
-    }
-
-    public function getName()
-    {
-        return 'netgen.field_rendering';
-    }
-
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction(
+            new TwigFunction(
                 'ng_render_field',
-                function (Twig_Environment $environment, Field $field, array $params = []) {
-                    $this->fieldBlockRenderer->setTwig($environment);
-
-                    return $this->renderField($field, $params);
-                },
-                [
-                    'is_safe' => [
-                        'html',
-                    ],
-                    'needs_environment' => true,
-                ]
+                [FieldRenderingRuntime::class, 'renderField'],
+                ['is_safe' => ['html']]
             ),
         ];
-    }
-
-    /**
-     * Renders the HTML for a given field.
-     *
-     * @throws InvalidArgumentException
-     *
-     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field
-     * @param array $params An array of parameters to pass to the field view
-     *
-     * @return string The HTML markup
-     */
-    public function renderField(Field $field, array $params = [])
-    {
-        $params = $this->getRenderFieldBlockParameters($field, $params);
-
-        return $this->fieldBlockRenderer->renderContentFieldView(
-            $field->innerField,
-            $field->fieldTypeIdentifier,
-            $params
-        );
-    }
-
-    /**
-     * Generates the array of parameter to pass to the field template.
-     *
-     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field the Field to display
-     * @param array $params An array of parameters to pass to the field view
-     *
-     * @return array
-     */
-    private function getRenderFieldBlockParameters(Field $field, array $params = [])
-    {
-        // Merging passed parameters to default ones
-        $params += [
-            'parameters' => [], // parameters dedicated to template processing
-            'attr' => [], // attributes to add on the enclosing HTML tags
-        ];
-
-        $content = $field->content->innerContent;
-        $contentType = $field->content->contentInfo->innerContentType;
-        $fieldDefinition = $contentType->getFieldDefinition($field->fieldDefIdentifier);
-
-        $params += [
-            'field' => $field->innerField,
-            'content' => $content,
-            'contentInfo' => $content->getVersionInfo()->getContentInfo(),
-            'versionInfo' => $content->getVersionInfo(),
-            'fieldSettings' => $fieldDefinition->getFieldSettings(),
-        ];
-
-        // Adding field type specific parameters if any.
-        if ($this->parameterProviderRegistry->hasParameterProvider($fieldDefinition->fieldTypeIdentifier)) {
-            $params['parameters'] += $this->parameterProviderRegistry
-                ->getParameterProvider($fieldDefinition->fieldTypeIdentifier)
-                ->getViewParameters($field->innerField);
-        }
-
-        // make sure we can easily add class="<fieldtypeidentifier>-field" to the
-        // generated HTML
-        if (isset($params['attr']['class'])) {
-            $params['attr']['class'] .= " {$field->fieldTypeIdentifier}-field";
-        } else {
-            $params['attr']['class'] = "{$field->fieldTypeIdentifier}-field";
-        }
-
-        return $params;
     }
 }

--- a/bundle/Templating/Twig/Extension/FieldRenderingRuntime.php
+++ b/bundle/Templating/Twig/Extension/FieldRenderingRuntime.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderRegistryInterface;
+use eZ\Publish\Core\MVC\Symfony\Templating\FieldBlockRendererInterface;
+use Netgen\EzPlatformSiteApi\API\Values\Field;
+use Twig\Environment;
+
+/**
+ * Twig extension for content fields rendering (view).
+ */
+class FieldRenderingRuntime
+{
+    /**
+     * @var \Twig\Environment
+     */
+    private $environment;
+
+    /**
+     * @var FieldBlockRendererInterface|\eZ\Publish\Core\MVC\Symfony\Templating\Twig\FieldBlockRenderer
+     */
+    private $fieldBlockRenderer;
+
+    /**
+     * @var ParameterProviderRegistryInterface
+     */
+    private $parameterProviderRegistry;
+
+    public function __construct(
+        Environment $environment,
+        FieldBlockRendererInterface $fieldBlockRenderer,
+        ParameterProviderRegistryInterface $parameterProviderRegistry
+    ) {
+        $this->environment = $environment;
+        $this->fieldBlockRenderer = $fieldBlockRenderer;
+        $this->parameterProviderRegistry = $parameterProviderRegistry;
+    }
+
+    /**
+     * Renders the HTML for a given field.
+     *
+     * @throws InvalidArgumentException
+     *
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field
+     * @param array $params An array of parameters to pass to the field view
+     *
+     * @return string The HTML markup
+     */
+    public function renderField(Field $field, array $params = [])
+    {
+        $this->fieldBlockRenderer->setTwig($this->environment);
+
+        $params = $this->getRenderFieldBlockParameters($field, $params);
+
+        return $this->fieldBlockRenderer->renderContentFieldView(
+            $field->innerField,
+            $field->fieldTypeIdentifier,
+            $params
+        );
+    }
+
+    /**
+     * Generates the array of parameter to pass to the field template.
+     *
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field the Field to display
+     * @param array $params An array of parameters to pass to the field view
+     *
+     * @return array
+     */
+    private function getRenderFieldBlockParameters(Field $field, array $params = [])
+    {
+        // Merging passed parameters to default ones
+        $params += [
+            'parameters' => [], // parameters dedicated to template processing
+            'attr' => [], // attributes to add on the enclosing HTML tags
+        ];
+
+        $content = $field->content->innerContent;
+        $contentType = $field->content->contentInfo->innerContentType;
+        $fieldDefinition = $contentType->getFieldDefinition($field->fieldDefIdentifier);
+
+        $params += [
+            'field' => $field->innerField,
+            'content' => $content,
+            'contentInfo' => $content->getVersionInfo()->getContentInfo(),
+            'versionInfo' => $content->getVersionInfo(),
+            'fieldSettings' => $fieldDefinition->getFieldSettings(),
+        ];
+
+        // Adding field type specific parameters if any.
+        if ($this->parameterProviderRegistry->hasParameterProvider($fieldDefinition->fieldTypeIdentifier)) {
+            $params['parameters'] += $this->parameterProviderRegistry
+                ->getParameterProvider($fieldDefinition->fieldTypeIdentifier)
+                ->getViewParameters($field->innerField);
+        }
+
+        // make sure we can easily add class="<fieldtypeidentifier>-field" to the
+        // generated HTML
+        if (isset($params['attr']['class'])) {
+            $params['attr']['class'] .= " {$field->fieldTypeIdentifier}-field";
+        } else {
+            $params['attr']['class'] = "{$field->fieldTypeIdentifier}-field";
+        }
+
+        return $params;
+    }
+}

--- a/bundle/Templating/Twig/Extension/ImageExtension.php
+++ b/bundle/Templating/Twig/Extension/ImageExtension.php
@@ -2,70 +2,19 @@
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
 
-use eZ\Publish\API\Repository\Exceptions\InvalidVariationException;
-use eZ\Publish\Core\MVC\Exception\SourceImageNotFoundException;
-use eZ\Publish\SPI\Variation\VariationHandler;
-use InvalidArgumentException;
-use Netgen\EzPlatformSiteApi\API\Values\Field;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class ImageExtension extends Twig_Extension
+class ImageExtension extends AbstractExtension
 {
-    /**
-     * @var VariationHandler
-     */
-    private $imageVariationService;
-
-    public function __construct(VariationHandler $imageVariationService)
-    {
-        $this->imageVariationService = $imageVariationService;
-    }
-
-    public function getName()
-    {
-        return 'netgen.image';
-    }
-
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction(
+            new TwigFunction(
                 'ng_image_alias',
-                [$this, 'getImageVariation'],
+                [ImageRuntime::class, 'getImageVariation'],
                 ['is_safe' => ['html']]
             ),
         ];
-    }
-
-    /**
-     * Returns the image variation object for $field/$versionInfo.
-     *
-     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field
-     * @param string $variationName
-     *
-     * @return \eZ\Publish\SPI\Variation\Values\Variation
-     */
-    public function getImageVariation(Field $field, $variationName)
-    {
-        try {
-            return $this->imageVariationService->getVariation($field->innerField, $field->content->versionInfo, $variationName);
-        } catch (InvalidVariationException $e) {
-            if (isset($this->logger)) {
-                $this->logger->error("Couldn't get variation '{$variationName}' for image with id {$field->value->id}");
-            }
-        } catch (SourceImageNotFoundException $e) {
-            if (isset($this->logger)) {
-                $this->logger->error(
-                    "Couldn't create variation '{$variationName}' for image with id {$field->value->id} because source image can't be found"
-                );
-            }
-        } catch (InvalidArgumentException $e) {
-            if (isset($this->logger)) {
-                $this->logger->error(
-                    "Couldn't create variation '{$variationName}' for image with id {$field->value->id} because an image could not be created from the given input"
-                );
-            }
-        }
     }
 }

--- a/bundle/Templating/Twig/Extension/ImageRuntime.php
+++ b/bundle/Templating/Twig/Extension/ImageRuntime.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
+
+use eZ\Publish\API\Repository\Exceptions\InvalidVariationException;
+use eZ\Publish\Core\MVC\Exception\SourceImageNotFoundException;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use InvalidArgumentException;
+use Netgen\EzPlatformSiteApi\API\Values\Field;
+
+class ImageRuntime
+{
+    /**
+     * @var VariationHandler
+     */
+    private $imageVariationService;
+
+    public function __construct(VariationHandler $imageVariationService)
+    {
+        $this->imageVariationService = $imageVariationService;
+    }
+
+    /**
+     * Returns the image variation object for $field/$versionInfo.
+     *
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Field $field
+     * @param string $variationName
+     *
+     * @return \eZ\Publish\SPI\Variation\Values\Variation
+     */
+    public function getImageVariation(Field $field, $variationName)
+    {
+        try {
+            return $this->imageVariationService->getVariation($field->innerField, $field->content->versionInfo, $variationName);
+        } catch (InvalidVariationException $e) {
+            if (isset($this->logger)) {
+                $this->logger->error("Couldn't get variation '{$variationName}' for image with id {$field->value->id}");
+            }
+        } catch (SourceImageNotFoundException $e) {
+            if (isset($this->logger)) {
+                $this->logger->error(
+                    "Couldn't create variation '{$variationName}' for image with id {$field->value->id} because source image can't be found"
+                );
+            }
+        } catch (InvalidArgumentException $e) {
+            if (isset($this->logger)) {
+                $this->logger->error(
+                    "Couldn't create variation '{$variationName}' for image with id {$field->value->id} because an image could not be created from the given input"
+                );
+            }
+        }
+    }
+}

--- a/bundle/Templating/Twig/Extension/QueryExtension.php
+++ b/bundle/Templating/Twig/Extension/QueryExtension.php
@@ -1,93 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
 
-use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryExecutor;
-use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
-use Twig_Error_Runtime;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Twig extension for executing queries from the QueryDefinitionCollection injected
  * into the template.
  */
-class QueryExtension extends Twig_Extension
+class QueryExtension extends AbstractExtension
 {
-    /**
-     * @var \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryExecutor
-     */
-    private $queryExecutor;
-
-    /**
-     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryExecutor $queryExecutor
-     */
-    public function __construct(QueryExecutor $queryExecutor)
-    {
-        $this->queryExecutor = $queryExecutor;
-    }
-
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
-            new Twig_SimpleFunction(
+            new TwigFunction(
                 'ng_query',
-                /**
-                 * @param mixed $context
-                 * @param string $name
-                 *
-                 * @return \Pagerfanta\Pagerfanta
-                 */
-                function ($context, $name) {
-                    return $this->queryExecutor->execute(
-                        $this->getQueryDefinitionCollection($context)->get($name),
-                        true
-                    );
-                },
-                [
-                    'needs_context' => true,
-                ]
+                [QueryRuntime::class, 'executeQuery'],
+                ['needs_context' => true]
             ),
-            new Twig_SimpleFunction(
+            new TwigFunction(
                 'ng_raw_query',
-                /**
-                 * @param mixed $context
-                 * @param string $name
-                 *
-                 * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
-                 */
-                function ($context, $name) {
-                    return $this->queryExecutor->execute(
-                        $this->getQueryDefinitionCollection($context)->get($name),
-                        false
-                    );
-                },
-                [
-                    'needs_context' => true,
-                ]
+                [QueryRuntime::class, 'executeRawQuery'],
+                ['needs_context' => true]
             ),
         ];
-    }
-
-    /**
-     * Returns the QueryDefinitionCollection variable from the given $context.
-     *
-     * @throws \Twig_Error_Runtime
-     *
-     * @param mixed $context
-     *
-     * @return \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinitionCollection
-     */
-    private function getQueryDefinitionCollection($context)
-    {
-        $variableName = ContentView::QUERY_DEFINITION_COLLECTION_NAME;
-
-        if (is_array($context) && array_key_exists($variableName, $context)) {
-            return $context[$variableName];
-        }
-
-        throw new Twig_Error_Runtime(
-            "Could not find QueryDefinitionCollection variable '{$variableName}'"
-        );
     }
 }

--- a/bundle/Templating/Twig/Extension/QueryRuntime.php
+++ b/bundle/Templating/Twig/Extension/QueryRuntime.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
+
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinitionCollection;
+use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryExecutor;
+use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
+use Pagerfanta\Pagerfanta;
+use Twig\Error\RuntimeError;
+
+/**
+ * Twig extension runtime for executing queries from the QueryDefinitionCollection injected
+ * into the template.
+ */
+class QueryRuntime
+{
+    /**
+     * @var \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryExecutor
+     */
+    private $queryExecutor;
+
+    /**
+     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryExecutor $queryExecutor
+     */
+    public function __construct(QueryExecutor $queryExecutor)
+    {
+        $this->queryExecutor = $queryExecutor;
+    }
+
+    /**
+     * @param $context
+     * @param string $name
+     *
+     * @throws \Pagerfanta\Exception\Exception
+     * @throws \Twig\Error\RuntimeError
+     *
+     * @return \Pagerfanta\Pagerfanta
+     */
+    public function executeQuery($context, string $name): Pagerfanta
+    {
+        return $this->queryExecutor->execute(
+            $this->getQueryDefinitionCollection($context)->get($name),
+            true
+        );
+    }
+
+    /**
+     * @param $context
+     * @param string $name
+     *
+     * @throws \Pagerfanta\Exception\Exception
+     * @throws \Twig\Error\RuntimeError
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    public function executeRawQuery($context, $name): SearchResult
+    {
+        return $this->queryExecutor->execute(
+            $this->getQueryDefinitionCollection($context)->get($name),
+            false
+        );
+    }
+
+    /**
+     * Returns the QueryDefinitionCollection variable from the given $context.
+     *
+     * @param mixed $context
+     *
+     * @throws \Twig\Error\RuntimeError
+     *
+     * @return \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinitionCollection
+     */
+    private function getQueryDefinitionCollection($context): QueryDefinitionCollection
+    {
+        $variableName = ContentView::QUERY_DEFINITION_COLLECTION_NAME;
+
+        if (is_array($context) && array_key_exists($variableName, $context)) {
+            return $context[$variableName];
+        }
+
+        throw new RuntimeError(
+            "Could not find QueryDefinitionCollection variable '{$variableName}'"
+        );
+    }
+}


### PR DESCRIPTION
* Twig runtimes provide separating Twig extension implementation from their definition
* Twig namespaces are available since newer versions of Twig