### PR TITLE
Fix setting current user to multiple Repositories

### DIFF
--- a/bundle/DependencyInjection/Compiler/AggregateRepositoryPass.php
+++ b/bundle/DependencyInjection/Compiler/AggregateRepositoryPass.php
@@ -44,21 +44,22 @@ class AggregateRepositoryPass implements CompilerPassInterface
     /**
      * @inheritdoc
      *
-     * @throws \LogicException
      * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @throws \Symfony\Component\DependencyInjection\Exception\OutOfBoundsException
+     * @throws \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
      */
     public function process(ContainerBuilder $container)
     {
         // 1. Register custom repositories with Aggregate repository
         $aggregateRepositoryDefinition = $container->findDefinition(static::$aggregateRepositoryId);
-        $customRepositories = $container->findTaggedServiceIds(static::$customRepositoryTag);
+        $customRepositoryTags = $container->findTaggedServiceIds(static::$customRepositoryTag);
+        $customRepositoryReferences = [];
 
-        foreach ($customRepositories as $id => $attributes) {
-            $aggregateRepositoryDefinition->addMethodCall(
-                'addRepository',
-                [new Reference($id)]
-            );
+        foreach (array_keys($customRepositoryTags) as $id) {
+            $customRepositoryReferences[] = new Reference($id);
         }
+
+        $aggregateRepositoryDefinition->replaceArgument(1, $customRepositoryReferences);
 
         $topEzRepositoryAlias = $container->getAlias(static::$topEzRepositoryAliasId);
 

--- a/bundle/DependencyInjection/Compiler/AggregateRepositoryPass.php
+++ b/bundle/DependencyInjection/Compiler/AggregateRepositoryPass.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Creates service aliases necessary for Aggregate Repository implementation to work.
+ *
+ * @see \Netgen\EzPlatformSiteApi\Core\Repository\Aggregate\Repository
+ */
+class AggregateRepositoryPass implements CompilerPassInterface
+{
+    /**
+     * Public service alias ID of the topmost eZ Platform repository.
+     *
+     * @var string
+     */
+    private static $topEzRepositoryAliasId = 'ezpublish.api.repository';
+
+    /**
+     * Out internal service alias ID of the topmost eZ Platform repository (created here).
+     *
+     * @var string
+     */
+    private static $renamedTopEzRepositoryAliasId = 'netgen.ezpublish.api.repository';
+
+    /**
+     * Service ID of the Aggregate Repository implementation.
+     *
+     * @var string
+     */
+    private static $aggregateRepositoryId = 'netgen.ezplatform_site.aggregate_repository';
+
+    /**
+     * @inheritdoc
+     *
+     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $topEzRepositoryAlias = $container->getAlias(static::$topEzRepositoryAliasId);
+
+        // 1. Re-link eZ Platform's public top Repository alias
+        $container->setAlias(static::$renamedTopEzRepositoryAliasId, (string)$topEzRepositoryAlias);
+
+        // 2. Overwrite eZ Platform's public top Repository alias
+        // to aggregate Repository implementation
+        $container->setAlias(static::$topEzRepositoryAliasId, static::$aggregateRepositoryId);
+    }
+}

--- a/bundle/NetgenEzPlatformSiteApiBundle.php
+++ b/bundle/NetgenEzPlatformSiteApiBundle.php
@@ -2,6 +2,7 @@
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle;
 
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\AggregateRepositoryPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\DefaultViewActionOverridePass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\PreviewControllerOverridePass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
@@ -16,6 +17,7 @@ class NetgenEzPlatformSiteApiBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new AggregateRepositoryPass());
         $container->addCompilerPass(new DefaultViewActionOverridePass());
         $container->addCompilerPass(new PreviewControllerOverridePass());
         $container->addCompilerPass(new RelationResolverRegistrationPass());

--- a/lib/Core/Repository/Aggregate/Repository.php
+++ b/lib/Core/Repository/Aggregate/Repository.php
@@ -41,20 +41,7 @@ class Repository implements RepositoryInterface
         array $customRepositories = []
     ) {
         $this->ezRepository = $ezRepository;
-
-        foreach ($customRepositories as $repository) {
-            $this->addRepository($repository);
-        }
-    }
-
-    /**
-     * Add a $repository to the internal collection.
-     *
-     * @param \eZ\Publish\API\Repository\Repository $repository
-     */
-    public function addRepository(RepositoryInterface $repository)
-    {
-        $this->customRepositories[] = $repository;
+        $this->customRepositories = $customRepositories;
     }
 
     public function getCurrentUser()

--- a/lib/Core/Repository/Aggregate/Repository.php
+++ b/lib/Core/Repository/Aggregate/Repository.php
@@ -27,7 +27,7 @@ class Repository implements RepositoryInterface
     /**
      * @var \eZ\Publish\API\Repository\Repository[]
      */
-    private $customRepositories;
+    private $customRepositories = [];
 
     /**
      * Construct repository object from top eZ Platform Repository and
@@ -38,10 +38,23 @@ class Repository implements RepositoryInterface
      */
     public function __construct(
         RepositoryInterface $ezRepository,
-        array $customRepositories
+        array $customRepositories = []
     ) {
         $this->ezRepository = $ezRepository;
-        $this->customRepositories = $customRepositories;
+
+        foreach ($customRepositories as $repository) {
+            $this->addRepository($repository);
+        }
+    }
+
+    /**
+     * Add a $repository to the internal collection.
+     *
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     */
+    public function addRepository(RepositoryInterface $repository)
+    {
+        $this->customRepositories[] = $repository;
     }
 
     public function getCurrentUser()

--- a/lib/Core/Repository/Aggregate/Repository.php
+++ b/lib/Core/Repository/Aggregate/Repository.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Repository\Aggregate;
+
+use eZ\Publish\API\Repository\Repository as RepositoryInterface;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use Closure;
+
+/**
+ * Aggregate implementation of Repository interface.
+ *
+ * When current Repository User is changed, any custom instance of Repository will not be updated.
+ * This implementation takes care of it by aggregating custom instances to update current User when
+ * necessary. For that to work, it must be registered as the top one, meaning that service alias
+ * 'ezpublish.api.repository' must point to it. This is taken care of by AggregateRepositoryPass.
+ *
+ * @see \Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\AggregateRepositoryPass
+ */
+class Repository implements RepositoryInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Repository
+     */
+    private $ezRepository;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Repository[]
+     */
+    private $customRepositories;
+
+    /**
+     * Construct repository object from top eZ Platform Repository and
+     * an array of custom Repositories
+     *
+     * @param \eZ\Publish\API\Repository\Repository $ezRepository
+     * @param \eZ\Publish\API\Repository\Repository[] $customRepositories
+     */
+    public function __construct(
+        RepositoryInterface $ezRepository,
+        array $customRepositories
+    ) {
+        $this->ezRepository = $ezRepository;
+        $this->customRepositories = $customRepositories;
+    }
+
+    public function getCurrentUser()
+    {
+        return $this->ezRepository->getCurrentUser();
+    }
+
+    public function getCurrentUserReference()
+    {
+        return $this->ezRepository->getCurrentUserReference();
+    }
+
+    public function setCurrentUser(UserReference $user)
+    {
+        foreach ($this->customRepositories as $customRepository) {
+            $customRepository->setCurrentUser($user);
+        }
+
+        return $this->ezRepository->setCurrentUser($user);
+    }
+
+    public function sudo(Closure $callback)
+    {
+        return $this->ezRepository->sudo($callback, $this);
+    }
+
+    public function hasAccess($module, $function, UserReference $user = null)
+    {
+        return $this->ezRepository->hasAccess($module, $function, $user);
+    }
+
+    public function canUser($module, $function, ValueObject $object, $targets = null)
+    {
+        return $this->ezRepository->canUser($module, $function, $object, $targets);
+    }
+
+    public function getContentService()
+    {
+        return $this->ezRepository->getContentService();
+    }
+
+    public function getContentLanguageService()
+    {
+        return $this->ezRepository->getContentLanguageService();
+    }
+
+    public function getContentTypeService()
+    {
+        return $this->ezRepository->getContentTypeService();
+    }
+
+    public function getLocationService()
+    {
+        return $this->ezRepository->getLocationService();
+    }
+
+    public function getTrashService()
+    {
+        return $this->ezRepository->getTrashService();
+    }
+
+    public function getSectionService()
+    {
+        return $this->ezRepository->getSectionService();
+    }
+
+    public function getUserService()
+    {
+        return $this->ezRepository->getUserService();
+    }
+
+    public function getURLAliasService()
+    {
+        return $this->ezRepository->getURLAliasService();
+    }
+
+    public function getURLWildcardService()
+    {
+        return $this->ezRepository->getURLWildcardService();
+    }
+
+    public function getObjectStateService()
+    {
+        return $this->ezRepository->getObjectStateService();
+    }
+
+    public function getRoleService()
+    {
+        return $this->ezRepository->getRoleService();
+    }
+
+    public function getSearchService()
+    {
+        return $this->ezRepository->getSearchService();
+    }
+
+    public function getFieldTypeService()
+    {
+        return $this->ezRepository->getFieldTypeService();
+    }
+
+    public function getURLService()
+    {
+        return $this->ezRepository->getURLService();
+    }
+
+    public function getPermissionResolver()
+    {
+        return $this->ezRepository->getPermissionResolver();
+    }
+
+    public function beginTransaction()
+    {
+        return $this->ezRepository->beginTransaction();
+    }
+
+    public function commit()
+    {
+        return $this->ezRepository->commit();
+    }
+
+    public function rollback()
+    {
+        return $this->ezRepository->rollback();
+    }
+
+    public function commitEvent($event)
+    {
+        return $this->ezRepository->commitEvent($event);
+    }
+
+    public function createDateTime($timestamp = null)
+    {
+        return $this->ezRepository->createDateTime($timestamp);
+    }
+}

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -5,6 +5,14 @@ parameters:
     netgen.ezplatform_site.root_location_id: 2
 
 services:
+    #
+    netgen.ezplatform_site.aggregate_repository:
+        class: Netgen\EzPlatformSiteApi\Core\Repository\Aggregate\Repository
+        arguments:
+            - '@netgen.ezpublish.api.repository'
+            -
+                - '@netgen.ezplatform_site.inner_repository'
+
     netgen.ezplatform_site.inner_repository:
         class: '%ezpublish.api.inner_repository.class%'
         factory:

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -11,6 +11,7 @@ services:
         class: Netgen\EzPlatformSiteApi\Core\Repository\Aggregate\Repository
         arguments:
             - '@netgen.ezpublish.api.repository'
+        public: false
 
     netgen.ezplatform_site.repository.inner:
         class: '%ezpublish.api.inner_repository.class%'

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -11,6 +11,7 @@ services:
         class: Netgen\EzPlatformSiteApi\Core\Repository\Aggregate\Repository
         arguments:
             - '@netgen.ezpublish.api.repository'
+            - []
         public: false
 
     netgen.ezplatform_site.repository.inner:

--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -5,15 +5,14 @@ parameters:
     netgen.ezplatform_site.root_location_id: 2
 
 services:
-    #
-    netgen.ezplatform_site.aggregate_repository:
+    # Services tagged with 'netgen.ezplatform_site.repository' are registered to this one
+    # through a compiler pass
+    netgen.ezplatform_site.repository.aggregate:
         class: Netgen\EzPlatformSiteApi\Core\Repository\Aggregate\Repository
         arguments:
             - '@netgen.ezpublish.api.repository'
-            -
-                - '@netgen.ezplatform_site.inner_repository'
 
-    netgen.ezplatform_site.inner_repository:
+    netgen.ezplatform_site.repository.inner:
         class: '%ezpublish.api.inner_repository.class%'
         factory:
             - '@ezpublish.api.repository.factory'
@@ -24,11 +23,13 @@ services:
             - '@?ezpublish.search.background_indexer'
         lazy: true
         public: false
+        tags:
+            - {name: netgen.ezplatform_site.repository}
 
     netgen.ezplatform_site.repository.filtering_search_service:
         class: '%ezpublish.api.service.search.class%'
         factory:
-            - '@netgen.ezplatform_site.inner_repository'
+            - '@netgen.ezplatform_site.repository.inner'
             - getSearchService
         lazy: true
         public: false

--- a/tests/lib/Integration/SetupFactory/Legacy.php
+++ b/tests/lib/Integration/SetupFactory/Legacy.php
@@ -4,6 +4,7 @@ namespace Netgen\EzPlatformSiteApi\Tests\Integration\SetupFactory;
 
 use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy as CoreLegacySetupFactory;
 use eZ\Publish\Core\Base\ServiceContainer;
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\AggregateRepositoryPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -23,6 +24,7 @@ class Legacy extends CoreLegacySetupFactory
             /* @var \Symfony\Component\DependencyInjection\ContainerBuilder $containerBuilder */
             $containerBuilder = include $config['container_builder_path'];
             $containerBuilder->addCompilerPass(new RelationResolverRegistrationPass());
+            $containerBuilder->addCompilerPass(new AggregateRepositoryPass());
 
             /* @var \Symfony\Component\DependencyInjection\Loader\YamlFileLoader $loader */
             $loader->load('search_engines/legacy.yml');


### PR DESCRIPTION
Fixes #64 

This fixes the problem of setting current Repository user, where Repository instance used to get SearchService with Legacy Search Engine (used for FilterService) was not updated. Current User is the only state Core Repository keeps.

The problem is fixed with new Aggregate Repository implementation, which is registered as public Repository (it rewrites `ezpublish.api.repository` alias). This implementation aggregates top eZ Platform Repository implementation (default `ezpublish.api.repository` alias) and our custom instance and updates current user on all of them.