### PR TITLE
[3.0] Introduce limit parameter to loadFieldRelations method

### DIFF
--- a/lib/API/RelationService.php
+++ b/lib/API/RelationService.php
@@ -37,7 +37,7 @@ interface RelationService
      * @param string|int $contentId
      * @param string $fieldDefinitionIdentifier
      * @param array $contentTypeIdentifiers
-     * @param int $limit
+     * @param int|null $limit
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
@@ -48,6 +48,6 @@ interface RelationService
         $contentId,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = [],
-        int $limit = 0
+        ?int $limit = null
     ): array;
 }

--- a/lib/API/RelationService.php
+++ b/lib/API/RelationService.php
@@ -37,6 +37,7 @@ interface RelationService
      * @param string|int $contentId
      * @param string $fieldDefinitionIdentifier
      * @param array $contentTypeIdentifiers
+     * @param int $limit
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
@@ -46,6 +47,7 @@ interface RelationService
     public function loadFieldRelations(
         $contentId,
         string $fieldDefinitionIdentifier,
-        array $contentTypeIdentifiers = []
+        array $contentTypeIdentifiers = [],
+        int $limit = 0
     ): array;
 }

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -87,7 +87,7 @@ class RelationService implements RelationServiceInterface
     }
 
     /**
-     * Return an array of all related Content from the given arguments if $limit is not provided.
+     * Return an array of related Content items, optionally limited by $limit.
      *
      * @param array $relatedContentIds
      * @param array $contentTypeIdentifiers

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -68,7 +68,7 @@ class RelationService implements RelationServiceInterface
         $contentId,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = [],
-        $limit = 0
+        int $limit = 0
     ): array {
         $content = $this->site->getLoadService()->loadContent($contentId);
 
@@ -97,7 +97,7 @@ class RelationService implements RelationServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content[]
      */
-    private function getRelatedContentItems(array $relatedContentIds, array $contentTypeIdentifiers, $limit = 0): array
+    private function getRelatedContentItems(array $relatedContentIds, array $contentTypeIdentifiers, int $limit = 0): array
     {
         if (count($relatedContentIds) === 0) {
             return [];
@@ -114,7 +114,7 @@ class RelationService implements RelationServiceInterface
 
         $query = new Query([
             'filter' => $criteria,
-            'limit' => is_int($limit) && $limit > 0 ? $limit : count($relatedContentIds),
+            'limit' => $limit > 0 ? $limit : count($relatedContentIds),
         ]);
 
         $searchResult = $this->site->getFilterService()->filterContent($query);

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -69,7 +69,7 @@ class RelationService implements RelationServiceInterface
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = [],
         $limit = 0
-    ) {
+    ): array {
         $content = $this->site->getLoadService()->loadContent($contentId);
 
         $field = $content->getField($fieldDefinitionIdentifier);

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -114,7 +114,7 @@ class RelationService implements RelationServiceInterface
 
         $query = new Query([
             'filter' => $criteria,
-            'limit' => $limit ? $limit : count($relatedContentIds),
+            'limit' => is_int($limit) && $limit > 0 ? $limit : count($relatedContentIds),
         ]);
 
         $searchResult = $this->site->getFilterService()->filterContent($query);

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -67,8 +67,9 @@ class RelationService implements RelationServiceInterface
     public function loadFieldRelations(
         $contentId,
         string $fieldDefinitionIdentifier,
-        array $contentTypeIdentifiers = []
-    ): array {
+        array $contentTypeIdentifiers = [],
+        $limit = 0
+    ) {
         $content = $this->site->getLoadService()->loadContent($contentId);
 
         $field = $content->getField($fieldDefinitionIdentifier);
@@ -77,7 +78,8 @@ class RelationService implements RelationServiceInterface
         $relatedContentIds = $relationResolver->getRelationIds($field);
         $relatedContentItems = $this->getRelatedContentItems(
             $relatedContentIds,
-            $contentTypeIdentifiers
+            $contentTypeIdentifiers,
+            $limit
         );
         $this->sortByIdOrder($relatedContentItems, $relatedContentIds);
 
@@ -85,16 +87,17 @@ class RelationService implements RelationServiceInterface
     }
 
     /**
-     * Return an array of related Content from the given arguments.
+     * Return an array of all related Content from the given arguments if $limit is not provided.
      *
      * @param array $relatedContentIds
      * @param array $contentTypeIdentifiers
+     * @param int $limit
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content[]
      */
-    private function getRelatedContentItems(array $relatedContentIds, array $contentTypeIdentifiers): array
+    private function getRelatedContentItems(array $relatedContentIds, array $contentTypeIdentifiers, $limit = 0): array
     {
         if (count($relatedContentIds) === 0) {
             return [];
@@ -111,7 +114,7 @@ class RelationService implements RelationServiceInterface
 
         $query = new Query([
             'filter' => $criteria,
-            'limit' => count($relatedContentIds),
+            'limit' => $limit ? $limit : count($relatedContentIds),
         ]);
 
         $searchResult = $this->site->getFilterService()->filterContent($query);

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -114,12 +114,16 @@ class RelationService implements RelationServiceInterface
 
         $query = new Query([
             'filter' => $criteria,
-            'limit' => $limit > 0 ? $limit : count($relatedContentIds),
+            'limit' => count($relatedContentIds),
         ]);
 
         $searchResult = $this->site->getFilterService()->filterContent($query);
         /** @var \eZ\Publish\API\Repository\Values\Content\Content[] $contentItems */
         $contentItems = $this->extractValueObjects($searchResult);
+
+        if ($limit !== 0) {
+            return array_slice($contentItems, 0, $limit);
+        }
 
         return $contentItems;
     }

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -68,7 +68,7 @@ class RelationService implements RelationServiceInterface
         $contentId,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = [],
-        int $limit = 0
+        ?int $limit = null
     ): array {
         $content = $this->site->getLoadService()->loadContent($contentId);
 
@@ -91,13 +91,13 @@ class RelationService implements RelationServiceInterface
      *
      * @param array $relatedContentIds
      * @param array $contentTypeIdentifiers
-     * @param int $limit
+     * @param int|null $limit
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content[]
      */
-    private function getRelatedContentItems(array $relatedContentIds, array $contentTypeIdentifiers, int $limit = 0): array
+    private function getRelatedContentItems(array $relatedContentIds, array $contentTypeIdentifiers, ?int $limit = null): array
     {
         if (count($relatedContentIds) === 0) {
             return [];
@@ -121,7 +121,7 @@ class RelationService implements RelationServiceInterface
         /** @var \eZ\Publish\API\Repository\Values\Content\Content[] $contentItems */
         $contentItems = $this->extractValueObjects($searchResult);
 
-        if ($limit !== 0) {
+        if ($limit !== null) {
             return array_slice($contentItems, 0, $limit);
         }
 

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -316,12 +316,12 @@ final class Content extends APIContent
 
     public function getFieldRelations(string $fieldDefinitionIdentifier, int $limit = 25): array
     {
-        $relations = $this->site->getRelationService()->loadFieldRelations(
+        return $this->site->getRelationService()->loadFieldRelations(
             $this->id,
             $fieldDefinitionIdentifier
+            [],
+            $limit
         );
-
-        return array_slice($relations, 0, $limit);
     }
 
     public function filterFieldRelations(

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -318,7 +318,7 @@ final class Content extends APIContent
     {
         return $this->site->getRelationService()->loadFieldRelations(
             $this->id,
-            $fieldDefinitionIdentifier
+            $fieldDefinitionIdentifier,
             [],
             $limit
         );

--- a/tests/lib/Integration/RelationServiceTest.php
+++ b/tests/lib/Integration/RelationServiceTest.php
@@ -134,6 +134,75 @@ class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
+    public function testLoadFieldRelationsWithTypeFilter(): void
+    {
+        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, ['landing_page']);
+
+        $this->assertEquals(1, count($contentItems));
+
+        $this->assertInstanceOf(Content::class, $contentItems[0]);
+        $this->assertEquals($testRelationIds[0], $contentItems[0]->id);
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testLoadFieldRelationsWithLimit(): void
+    {
+        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, [], 1);
+
+        $this->assertEquals(1, count($contentItems));
+
+        $this->assertInstanceOf(Content::class, $contentItems[0]);
+        $this->assertEquals($testRelationIds[0], $contentItems[0]->id);
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testLoadFieldRelationsWithTypeFilterAndLimit(): void
+    {
+        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, ['feedback_form'], 1);
+
+        $this->assertEquals(1, count($contentItems));
+
+        $this->assertInstanceOf(Content::class, $contentItems[0]);
+        $this->assertEquals($testRelationIds[1], $contentItems[0]->id);
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
     public function testLoadFieldRelationsForNonexistentField(): void
     {
         [, , , $testApiContent] = $this->prepareTestContent();


### PR DESCRIPTION
In order to skip the slicing of the filter query result array which contains all the relations, limit parameter needs to be propagated all the way to the getRelatedContentItems method which will ensure that the resulting array has limited result returned.

This will not affect/break previous versions