### PR TITLE
Fix building repository on eZ kernel 7.1

### DIFF
--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -23,6 +23,7 @@ services:
             - '@ezpublish.api.persistence_handler'
             - '@ezpublish.spi.search.legacy'
             - '@?ezpublish.search.background_indexer'
+            - '@?ezpublish.repository.relation_processor'
         lazy: true
         public: false
         tags:


### PR DESCRIPTION
https://github.com/ezsystems/ezpublish-kernel/pull/2253 added a new parameter to `RepositoryFactory::buildRepository`, so we need to add it here.

Similar to https://github.com/netgen/ezplatform-site-api/pull/56