### PR TITLE
Refactor Pagerfanta adapters

### DIFF
--- a/bundle/Controller/Controller.php
+++ b/bundle/Controller/Controller.php
@@ -4,22 +4,26 @@ namespace Netgen\Bundle\EzPlatformSiteApiBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller as BaseController;
 use Netgen\EzPlatformSiteApi\Core\Traits\PagerfantaFindTrait;
+use Netgen\EzPlatformSiteApi\Core\Traits\PagerfantaTrait;
 use Netgen\EzPlatformSiteApi\Core\Traits\SearchResultExtractorTrait;
 
 abstract class Controller extends BaseController
 {
     use SearchResultExtractorTrait;
     use PagerfantaFindTrait;
+    use PagerfantaTrait;
 
     /**
      * Returns the root location object for current siteaccess configuration.
+     *
+     * @throws \Netgen\EzPlatformSiteApi\API\Exceptions\TranslationNotMatchedException
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location
      */
     public function getRootLocation()
     {
         return $this->getSite()->getLoadService()->loadLocation(
-            $this->getConfigResolver()->getParameter('content.tree_root.location_id')
+            $this->getSite()->getSettings()->rootLocationId
         );
     }
 

--- a/bundle/QueryType/QueryExecutor.php
+++ b/bundle/QueryType/QueryExecutor.php
@@ -7,10 +7,8 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\QueryType\QueryTypeRegistry;
 use Netgen\EzPlatformSiteApi\API\FilterService;
 use Netgen\EzPlatformSiteApi\API\FindService;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\ContentSearchAdapter;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\ContentSearchFilterAdapter;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchAdapter;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchFilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FindAdapter;
 use Pagerfanta\Pagerfanta;
 use RuntimeException;
 
@@ -67,46 +65,58 @@ final class QueryExecutor
         $queryType = $this->queryTypeRegistry->getQueryType($queryDefinition->name);
         $query = $queryType->getQuery($queryDefinition->parameters);
 
+        if ($usePager) {
+            return $this->getPager($query, $queryDefinition);
+        }
+
         if ($query instanceof LocationQuery) {
-            return $this->getLocationResult($query, $queryDefinition, $usePager);
+            return $this->getLocationResult($query, $queryDefinition);
         }
 
         if ($query instanceof Query) {
-            return $this->getContentResult($query, $queryDefinition, $usePager);
+            return $this->getContentResult($query, $queryDefinition);
         }
 
         throw new RuntimeException('Could not handle given query');
     }
 
     /**
-     * Return search result by the given parameters.
+     * Return Pagerfanta instance by the given parameters.
      *
      * @throws \Pagerfanta\Exception\Exception
      *
-     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
      * @param \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinition $queryDefinition
-     * @param bool $usePager
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult|\Pagerfanta\Pagerfanta
+     * @return \Pagerfanta\Pagerfanta
      */
-    private function getLocationResult(LocationQuery $query, QueryDefinition $queryDefinition, $usePager)
+    private function getPager(Query $query, QueryDefinition $queryDefinition)
     {
-        if ($usePager) {
-            if ($queryDefinition->useFilter) {
-                $adapter = new LocationSearchFilterAdapter($query, $this->filterService);
-            } else {
-                $adapter = new LocationSearchAdapter($query, $this->findService);
-            }
-
-            $pager = new Pagerfanta($adapter);
-
-            $pager->setNormalizeOutOfRangePages(true);
-            $pager->setMaxPerPage($queryDefinition->maxPerPage);
-            $pager->setCurrentPage($queryDefinition->page);
-
-            return $pager;
+        if ($queryDefinition->useFilter) {
+            $adapter = new FilterAdapter($query, $this->filterService);
+        } else {
+            $adapter = new FindAdapter($query, $this->findService);
         }
 
+        $pager = new Pagerfanta($adapter);
+
+        $pager->setNormalizeOutOfRangePages(true);
+        $pager->setMaxPerPage($queryDefinition->maxPerPage);
+        $pager->setCurrentPage($queryDefinition->page);
+
+        return $pager;
+    }
+
+    /**
+     * Return search result by the given parameters.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinition $queryDefinition
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    private function getLocationResult(LocationQuery $query, QueryDefinition $queryDefinition)
+    {
         if ($queryDefinition->useFilter) {
             return $this->filterService->filterLocations($query);
         }
@@ -117,32 +127,13 @@ final class QueryExecutor
     /**
      * Return search result by the given parameters.
      *
-     * @throws \Pagerfanta\Exception\Exception
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
      * @param \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinition $queryDefinition
-     * @param bool $usePager
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult|\Pagerfanta\Pagerfanta
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    private function getContentResult(Query $query, QueryDefinition $queryDefinition, $usePager)
+    private function getContentResult(Query $query, QueryDefinition $queryDefinition)
     {
-        if ($usePager) {
-            if ($queryDefinition->useFilter) {
-                $adapter = new ContentSearchFilterAdapter($query, $this->filterService);
-            } else {
-                $adapter = new ContentSearchAdapter($query, $this->findService);
-            }
-
-            $pager = new Pagerfanta($adapter);
-
-            $pager->setNormalizeOutOfRangePages(true);
-            $pager->setMaxPerPage($queryDefinition->maxPerPage);
-            $pager->setCurrentPage($queryDefinition->page);
-
-            return $pager;
-        }
-
         if ($queryDefinition->useFilter) {
             return $this->filterService->filterContent($query);
         }

--- a/lib/Core/Site/Pagination/Pagerfanta/BaseAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/BaseAdapter.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\SearchResultExtras;
+use Pagerfanta\Adapter\AdapterInterface;
+
+/**
+ * Base Site API search adapter.
+ */
+abstract class BaseAdapter implements AdapterInterface, SearchResultExtras
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Query
+     */
+    private $query;
+
+    /**
+     * @var int
+     */
+    private $nbResults;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Search\Facet[]
+     */
+    private $facets;
+
+    /**
+     * @var float
+     */
+    private $maxScore;
+
+    /**
+     * @var int
+     */
+    private $time;
+
+    /**
+     * @var bool
+     */
+    private $isExtraInfoInitialized = false;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     */
+    public function __construct(Query $query)
+    {
+        $this->query = $query;
+    }
+
+    public function getNbResults()
+    {
+        $this->initializeExtraInfo();
+
+        return $this->nbResults;
+    }
+
+    public function getFacets()
+    {
+        $this->initializeExtraInfo();
+
+        return $this->facets;
+    }
+
+    public function getMaxScore()
+    {
+        $this->initializeExtraInfo();
+
+        return $this->maxScore;
+    }
+
+    public function getTime()
+    {
+        return $this->time;
+    }
+
+    public function getSlice($offset, $length)
+    {
+        $query = clone $this->query;
+        $query->offset = $offset;
+        $query->limit = $length;
+        $query->performCount = false;
+
+        $searchResult = $this->executeQuery($query);
+
+        $this->time = $searchResult->time;
+
+        if (!$this->isExtraInfoInitialized && $searchResult->totalCount !== null) {
+            $this->setExtraInfo($searchResult);
+        }
+
+        return new Slice($searchResult->searchHits);
+    }
+
+    /**
+     * Execute the given $query and return SearchResult instance.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    abstract protected function executeQuery(Query $query);
+
+    private function initializeExtraInfo()
+    {
+        if ($this->isExtraInfoInitialized) {
+            return;
+        }
+
+        $query = clone $this->query;
+        $query->limit = 0;
+        $searchResult = $this->executeQuery($query);
+
+        $this->setExtraInfo($searchResult);
+    }
+
+    private function setExtraInfo(SearchResult $searchResult)
+    {
+        $this->facets = $searchResult->facets;
+        $this->maxScore = $searchResult->maxScore;
+        $this->nbResults = $searchResult->totalCount;
+
+        $this->isExtraInfoInitialized = true;
+    }
+}

--- a/lib/Core/Site/Pagination/Pagerfanta/ContentInfoSearchHitAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/ContentInfoSearchHitAdapter.php
@@ -31,6 +31,11 @@ class ContentInfoSearchHitAdapter implements AdapterInterface
 
     public function __construct(Query $query, FindService $findService)
     {
+        @trigger_error(
+            'ContentInfoSearchHitAdapter is deprecated since version 2.2 and will be removed in 3.0. Use FindAdapter or FilterAdapter instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->query = $query;
         $this->findService = $findService;
     }

--- a/lib/Core/Site/Pagination/Pagerfanta/ContentSearchAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/ContentSearchAdapter.php
@@ -3,6 +3,8 @@
 namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
 
 /**
+ * @deprecated since version 2.5, to be removed in 3.0. Use FindAdapter or FilterAdapter instead.
+ *
  * Pagerfanta adapter for Netgen eZ Platform Site Content search.
  * Will return results as Site Content objects.
  */

--- a/lib/Core/Site/Pagination/Pagerfanta/ContentSearchFilterAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/ContentSearchFilterAdapter.php
@@ -7,6 +7,8 @@ use Netgen\EzPlatformSiteApi\API\FilterService;
 use Pagerfanta\Adapter\AdapterInterface;
 
 /**
+ * @deprecated since version 2.5, to be removed in 3.0. Use FindAdapter or FilterAdapter instead.
+ *
  * Pagerfanta adapter for Netgen eZ Platform Site Content filtering.
  * Will return results as Site Location objects.
  */
@@ -33,6 +35,11 @@ class ContentSearchFilterAdapter implements AdapterInterface
      */
     public function __construct(Query $query, FilterService $filterService)
     {
+        @trigger_error(
+            'ContentSearchFilterAdapter is deprecated since version 2.5 and will be removed in 3.0. Use FindAdapter or FilterAdapter instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->query = $query;
         $this->filterService = $filterService;
     }

--- a/lib/Core/Site/Pagination/Pagerfanta/ContentSearchHitAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/ContentSearchHitAdapter.php
@@ -7,6 +7,8 @@ use Netgen\EzPlatformSiteApi\API\FindService;
 use Pagerfanta\Adapter\AdapterInterface;
 
 /**
+ * @deprecated since version 2.5, to be removed in 3.0. Use FindAdapter or FilterAdapter instead.
+ *
  * Pagerfanta adapter for Netgen eZ Platform Site Content search.
  * Will return results as SearchHit objects.
  */
@@ -39,6 +41,11 @@ class ContentSearchHitAdapter implements AdapterInterface
 
     public function __construct(Query $query, FindService $findService)
     {
+        @trigger_error(
+            'ContentSearchHitAdapter is deprecated since version 2.5 and will be removed in 3.0. Use FindAdapter or FilterAdapter instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->query = $query;
         $this->findService = $findService;
     }

--- a/lib/Core/Site/Pagination/Pagerfanta/FilterAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/FilterAdapter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use Netgen\EzPlatformSiteApi\API\FilterService;
+
+/**
+ * Pagerfanta adapter performing search using FilterService.
+ *
+ * @see \Netgen\EzPlatformSiteApi\API\FilterService
+ */
+final class FilterAdapter extends BaseAdapter
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FilterService
+     */
+    private $filterService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param \Netgen\EzPlatformSiteApi\API\FilterService $filterService
+     */
+    public function __construct(Query $query, FilterService $filterService)
+    {
+        parent::__construct($query);
+
+        $this->filterService = $filterService;
+    }
+
+    protected function executeQuery(Query $query)
+    {
+        if ($query instanceof LocationQuery) {
+            return $this->filterService->filterLocations($query);
+        }
+
+        return $this->filterService->filterContent($query);
+    }
+}

--- a/lib/Core/Site/Pagination/Pagerfanta/FindAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/FindAdapter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use Netgen\EzPlatformSiteApi\API\FindService;
+
+/**
+ * Pagerfanta adapter performing search using FindService.
+ *
+ * @see \Netgen\EzPlatformSiteApi\API\FindService
+ */
+final class FindAdapter extends BaseAdapter
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FindService
+     */
+    private $findService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param \Netgen\EzPlatformSiteApi\API\FindService $findService
+     */
+    public function __construct(Query $query, FindService $findService)
+    {
+        parent::__construct($query);
+
+        $this->findService = $findService;
+    }
+
+    protected function executeQuery(Query $query)
+    {
+        if ($query instanceof LocationQuery) {
+            return $this->findService->findLocations($query);
+        }
+
+        return $this->findService->findContent($query);
+    }
+}

--- a/lib/Core/Site/Pagination/Pagerfanta/LocationSearchAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/LocationSearchAdapter.php
@@ -3,6 +3,8 @@
 namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
 
 /**
+ * @deprecated since version 2.5, to be removed in 3.0. Use FindAdapter or FilterAdapter instead.
+ *
  * Pagerfanta adapter for Netgen eZ Platform Site Location search.
  * Will return results as Site Location objects.
  */

--- a/lib/Core/Site/Pagination/Pagerfanta/LocationSearchFilterAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/LocationSearchFilterAdapter.php
@@ -7,6 +7,8 @@ use Netgen\EzPlatformSiteApi\API\FilterService;
 use Pagerfanta\Adapter\AdapterInterface;
 
 /**
+ * @deprecated since version 2.5, to be removed in 3.0. Use FindAdapter or FilterAdapter instead.
+ *
  * Pagerfanta adapter for Netgen eZ Platform Site Location filtering.
  * Will return results as Site Location objects.
  */
@@ -43,6 +45,11 @@ class LocationSearchFilterAdapter implements AdapterInterface
      */
     public function __construct(LocationQuery $query, FilterService $filterService)
     {
+        @trigger_error(
+            'LocationSearchFilterAdapter is deprecated since version 2.5 and will be removed in 3.0. Use FindAdapter or FilterAdapter instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->query = $query;
         $this->filterService = $filterService;
     }

--- a/lib/Core/Site/Pagination/Pagerfanta/LocationSearchHitAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/LocationSearchHitAdapter.php
@@ -7,6 +7,8 @@ use Netgen\EzPlatformSiteApi\API\FindService;
 use Pagerfanta\Adapter\AdapterInterface;
 
 /**
+ * @deprecated since version 2.5, to be removed in 3.0. Use FindAdapter or FilterAdapter instead.
+ *
  * Pagerfanta adapter for Netgen eZ Platform Site Location search.
  * Will return results as SearchHit objects.
  */
@@ -39,6 +41,11 @@ class LocationSearchHitAdapter implements AdapterInterface
 
     public function __construct(LocationQuery $query, FindService $findService)
     {
+        @trigger_error(
+            'LocationSearchHitAdapter is deprecated since version 2.5 and will be removed in 3.0. Use FindAdapter or FilterAdapter instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->query = $query;
         $this->findService = $findService;
     }

--- a/lib/Core/Site/Pagination/Pagerfanta/NodeSearchHitAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/NodeSearchHitAdapter.php
@@ -31,6 +31,11 @@ class NodeSearchHitAdapter implements AdapterInterface
 
     public function __construct(LocationQuery $query, FindService $findService)
     {
+        @trigger_error(
+            'NodeSearchHitAdapter is deprecated since version 2.1 and will be removed in 3.0. Use FindAdapter or FilterAdapter instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->query = $query;
         $this->findService = $findService;
     }

--- a/lib/Core/Site/Pagination/Pagerfanta/Slice.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/Slice.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
+
+use ArrayIterator;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+
+/**
+ * Implements ArrayIterator over SearchHit values and access to the array of
+ * the given SearchHit instances.
+ */
+final class Slice extends ArrayIterator
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Search\SearchHit[]
+     */
+    private $searchHits;
+
+    public function __construct(array $searchHits)
+    {
+        $this->searchHits = $searchHits;
+
+        parent::__construct(
+            array_map(
+                function (SearchHit $searchHit) {
+                    return $searchHit->valueObject;
+                },
+                $searchHits
+            )
+        );
+    }
+
+    public function getSearchHits()
+    {
+        return $this->searchHits;
+    }
+}

--- a/lib/Core/Site/Pagination/Pagerfanta/Slice.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/Slice.php
@@ -4,12 +4,13 @@ namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
 
 use ArrayIterator;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use IteratorAggregate;
 
 /**
- * Implements ArrayIterator over SearchHit values and access to the array of
- * the given SearchHit instances.
+ * Implements IteratorAggregate with access to the array of the SearchHit instances
+ * and aggregated ArrayIterator over values contained in them.
  */
-final class Slice extends ArrayIterator
+final class Slice implements IteratorAggregate
 {
     /**
      * @var \eZ\Publish\API\Repository\Values\Content\Search\SearchHit[]
@@ -19,19 +20,22 @@ final class Slice extends ArrayIterator
     public function __construct(array $searchHits)
     {
         $this->searchHits = $searchHits;
-
-        parent::__construct(
-            array_map(
-                function (SearchHit $searchHit) {
-                    return $searchHit->valueObject;
-                },
-                $searchHits
-            )
-        );
     }
 
     public function getSearchHits()
     {
         return $this->searchHits;
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator(
+            array_map(
+                function (SearchHit $searchHit) {
+                    return $searchHit->valueObject;
+                },
+                $this->searchHits
+            )
+        );
     }
 }

--- a/lib/Core/Site/Pagination/SearchResultExtras.php
+++ b/lib/Core/Site/Pagination/SearchResultExtras.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination;
+
+/**
+ * Defines access to extra information of the search query result.
+ */
+interface SearchResultExtras
+{
+    /**
+     * The facets for the search query.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\Facet[]
+     */
+    public function getFacets();
+
+    /**
+     * The maximum score for the search query.
+     *
+     * @return float
+     */
+    public function getMaxScore();
+
+    /**
+     * The duration of the search processing in ms.
+     *
+     * Note: this will be available only if the query is executed.
+     *
+     * @return int|null
+     */
+    public function getTime();
+}

--- a/lib/Core/Traits/PagerfantaFindTrait.php
+++ b/lib/Core/Traits/PagerfantaFindTrait.php
@@ -11,6 +11,10 @@ use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchHitAd
 use Pagerfanta\Adapter\AdapterInterface;
 use Pagerfanta\Pagerfanta;
 
+/**
+ * @deprecated since version 2.5, to be removed in 3.0. Use PagerfantaTrait instead.
+ * @see \Netgen\EzPlatformSiteApi\Core\Traits\PagerfantaTrait
+ */
 trait PagerfantaFindTrait
 {
     use SiteAwareTrait;
@@ -28,6 +32,11 @@ trait PagerfantaFindTrait
      */
     protected function createContentSearchPager(Query $query, $currentPage, $maxPerPage)
     {
+        @trigger_error(
+            'PagerfantaFindTrait is deprecated since version 2.5 and will be removed in 3.0. Use PagerfantaTrait instead.',
+            E_USER_DEPRECATED
+        );
+
         $adapter = new ContentSearchAdapter($query, $this->getSite()->getFindService());
 
         return $this->getPager($adapter, $currentPage, $maxPerPage);
@@ -46,6 +55,11 @@ trait PagerfantaFindTrait
      */
     protected function createContentSearchHitPager(Query $query, $currentPage, $maxPerPage)
     {
+        @trigger_error(
+            'PagerfantaFindTrait is deprecated since version 2.5 and will be removed in 3.0. Use PagerfantaTrait instead.',
+            E_USER_DEPRECATED
+        );
+
         $adapter = new ContentSearchHitAdapter($query, $this->getSite()->getFindService());
 
         return $this->getPager($adapter, $currentPage, $maxPerPage);
@@ -64,6 +78,11 @@ trait PagerfantaFindTrait
      */
     protected function createLocationSearchPager(LocationQuery $locationQuery, $currentPage, $maxPerPage)
     {
+        @trigger_error(
+            'PagerfantaFindTrait is deprecated since version 2.5 and will be removed in 3.0. Use PagerfantaTrait instead.',
+            E_USER_DEPRECATED
+        );
+
         $adapter = new LocationSearchAdapter($locationQuery, $this->getSite()->getFindService());
 
         return $this->getPager($adapter, $currentPage, $maxPerPage);
@@ -82,6 +101,11 @@ trait PagerfantaFindTrait
      */
     protected function createLocationSearchHitPager(LocationQuery $locationQuery, $currentPage, $maxPerPage)
     {
+        @trigger_error(
+            'PagerfantaFindTrait is deprecated since version 2.5 and will be removed in 3.0. Use PagerfantaTrait instead.',
+            E_USER_DEPRECATED
+        );
+
         $adapter = new LocationSearchHitAdapter($locationQuery, $this->getSite()->getFindService());
 
         return $this->getPager($adapter, $currentPage, $maxPerPage);
@@ -99,6 +123,11 @@ trait PagerfantaFindTrait
      */
     protected function getPager(AdapterInterface $adapter, $currentPage, $maxPerPage)
     {
+        @trigger_error(
+            'PagerfantaFindTrait is deprecated since version 2.5 and will be removed in 3.0. Use PagerfantaTrait instead.',
+            E_USER_DEPRECATED
+        );
+
         $pager = new Pagerfanta($adapter);
         $pager->setNormalizeOutOfRangePages(true);
         $pager->setMaxPerPage($maxPerPage);

--- a/lib/Core/Traits/PagerfantaTrait.php
+++ b/lib/Core/Traits/PagerfantaTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Core\Traits;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FindAdapter;
+use Pagerfanta\Pagerfanta;
+
+/**
+ * Provides methods to build Pagerfanta instance using on FilterAdapter or FindAdapter.
+ *
+ * Note: expects that SiteAwareTrait is also used.
+ * @see \Netgen\EzPlatformSiteApi\Core\Traits\SiteAwareTrait
+ */
+trait PagerfantaTrait
+{
+    /**
+     * Return Pagerfanta instance using FilterAdapter for the given $query.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param int $currentPage
+     * @param int $maxPerPage
+     *
+     * @return \Pagerfanta\Pagerfanta
+     */
+    protected function getFilterPager(Query $query, $currentPage, $maxPerPage)
+    {
+        $adapter = new FilterAdapter($query, $this->getSite()->getFilterService());
+        $pager = new Pagerfanta($adapter);
+
+        $pager->setNormalizeOutOfRangePages(true);
+        $pager->setMaxPerPage($maxPerPage);
+        $pager->setCurrentPage($currentPage);
+
+        return $pager;
+    }
+
+    /**
+     * Return Pagerfanta instance using FindAdapter for the given $query.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param int $currentPage
+     * @param int $maxPerPage
+     *
+     * @return \Pagerfanta\Pagerfanta
+     */
+    protected function getFindPager(Query $query, $currentPage, $maxPerPage)
+    {
+        $adapter = new FindAdapter($query, $this->getSite()->getFindService());
+        $pager = new Pagerfanta($adapter);
+
+        $pager->setNormalizeOutOfRangePages(true);
+        $pager->setMaxPerPage($maxPerPage);
+        $pager->setCurrentPage($currentPage);
+
+        return $pager;
+    }
+}

--- a/tests/bundle/QueryType/QueryExecutorTest.php
+++ b/tests/bundle/QueryType/QueryExecutorTest.php
@@ -12,10 +12,8 @@ use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinition;
 use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryExecutor;
 use Netgen\EzPlatformSiteApi\API\FilterService;
 use Netgen\EzPlatformSiteApi\API\FindService;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\ContentSearchAdapter;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\ContentSearchFilterAdapter;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchAdapter;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchFilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FindAdapter;
 use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -60,7 +58,7 @@ class QueryExecutorTest extends TestCase
         );
 
         $this->assertInstanceOf(Pagerfanta::class, $result);
-        $this->assertInstanceOf(ContentSearchFilterAdapter::class, $result->getAdapter());
+        $this->assertInstanceOf(FilterAdapter::class, $result->getAdapter());
         $this->assertEquals(20, $result->getMaxPerPage());
         $this->assertEquals(2, $result->getCurrentPage());
         $this->assertTrue($result->getNormalizeOutOfRangePages());
@@ -104,7 +102,7 @@ class QueryExecutorTest extends TestCase
         );
 
         $this->assertInstanceOf(Pagerfanta::class, $result);
-        $this->assertInstanceOf(ContentSearchAdapter::class, $result->getAdapter());
+        $this->assertInstanceOf(FindAdapter::class, $result->getAdapter());
         $this->assertEquals(20, $result->getMaxPerPage());
         $this->assertEquals(2, $result->getCurrentPage());
         $this->assertTrue($result->getNormalizeOutOfRangePages());
@@ -148,7 +146,7 @@ class QueryExecutorTest extends TestCase
         );
 
         $this->assertInstanceOf(Pagerfanta::class, $result);
-        $this->assertInstanceOf(LocationSearchFilterAdapter::class, $result->getAdapter());
+        $this->assertInstanceOf(FilterAdapter::class, $result->getAdapter());
         $this->assertEquals(20, $result->getMaxPerPage());
         $this->assertEquals(2, $result->getCurrentPage());
         $this->assertTrue($result->getNormalizeOutOfRangePages());
@@ -192,7 +190,7 @@ class QueryExecutorTest extends TestCase
         );
 
         $this->assertInstanceOf(Pagerfanta::class, $result);
-        $this->assertInstanceOf(LocationSearchAdapter::class, $result->getAdapter());
+        $this->assertInstanceOf(FindAdapter::class, $result->getAdapter());
         $this->assertEquals(20, $result->getMaxPerPage());
         $this->assertEquals(2, $result->getCurrentPage());
         $this->assertTrue($result->getNormalizeOutOfRangePages());
@@ -214,7 +212,7 @@ class QueryExecutorTest extends TestCase
                 'maxPerPage' => 20,
                 'page' => 2,
             ]),
-            true
+            false
         );
     }
 

--- a/tests/lib/Unit/Pagination/Pagerfanta/FilterAdapterTest.php
+++ b/tests/lib/Unit/Pagination/Pagerfanta/FilterAdapterTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Tests\Unit\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Netgen\EzPlatformSiteApi\API\FilterService;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\ContentSearchHitAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\Slice;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group pager
+ */
+class FilterAdapterTest extends TestCase
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FilterService|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $filterService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->filterService = $this->getMockBuilder(FilterService::class)
+            ->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+    }
+
+    public function testGetNbResults()
+    {
+        $nbResults = 123;
+        $query = new Query(['limit' => 10]);
+        $countQuery = clone $query;
+        $countQuery->limit = 0;
+        $searchResult = new SearchResult(['totalCount' => $nbResults]);
+
+        $this->filterService
+            ->expects($this->once())
+            ->method('filterContent')
+            ->with($this->equalTo($countQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query);
+
+        $this->assertSame($nbResults, $adapter->getNbResults());
+        $this->assertSame($nbResults, $adapter->getNbResults());
+    }
+
+    public function testGetFacets()
+    {
+        $facets = ['facet', 'facet'];
+        $query = new Query(['limit' => 10]);
+        $countQuery = clone $query;
+        $countQuery->limit = 0;
+        $searchResult = new SearchResult(['facets' => $facets]);
+
+        $this->filterService
+            ->expects($this->once())
+            ->method('filterContent')
+            ->with($this->equalTo($countQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query);
+
+        $this->assertSame($facets, $adapter->getFacets());
+        $this->assertSame($facets, $adapter->getFacets());
+    }
+
+    public function testMaxScore()
+    {
+        $maxScore = 100;
+        $query = new Query(['limit' => 10]);
+        $countQuery = clone $query;
+        $countQuery->limit = 0;
+        $searchResult = new SearchResult(['maxScore' => $maxScore]);
+
+        $this->filterService
+            ->expects($this->once())
+            ->method('filterContent')
+            ->with($this->equalTo($countQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query);
+
+        $this->assertSame($maxScore, $adapter->getMaxScore());
+        $this->assertSame($maxScore, $adapter->getMaxScore());
+    }
+
+    public function testTimeIsNotSet()
+    {
+        $this->filterService
+            ->expects($this->never())
+            ->method('filterContent');
+
+        $adapter = $this->getAdapter(new Query());
+
+        $this->assertNull($adapter->getTime());
+        $this->assertNull($adapter->getTime());
+    }
+
+    public function testGetSlice()
+    {
+        $offset = 20;
+        $limit = 25;
+        $nbResults = 123;
+        $facets = ['facet', 'facet'];
+        $maxScore = 100;
+        $time = 256;
+        $query = new Query(['offset' => 5, 'limit' => 10]);
+        $searchQuery = clone $query;
+        $searchQuery->offset = $offset;
+        $searchQuery->limit = $limit;
+        $searchQuery->performCount = false;
+
+        $hits = [new SearchHit(['valueObject' => 'Content'])];
+        $searchResult = new SearchResult([
+            'searchHits' => $hits,
+            'totalCount' => $nbResults,
+            'facets' => $facets,
+            'maxScore' => $maxScore,
+            'time' => $time,
+        ]);
+
+        $this->filterService
+            ->expects($this->once())
+            ->method('filterContent')
+            ->with($this->equalTo($searchQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query);
+        $slice = $adapter->getSlice($offset, $limit);
+
+        $this->assertInstanceOf(Slice::class, $slice);
+        $this->assertSame($hits, $slice->getSearchHits());
+        $this->assertSame($nbResults, $adapter->getNbResults());
+        $this->assertSame($facets, $adapter->getFacets());
+        $this->assertSame($maxScore, $adapter->getMaxScore());
+        $this->assertSame($time, $adapter->getTime());
+    }
+
+    public function testLocationQuery()
+    {
+        $query = new LocationQuery(['performCount' => false]);
+
+        $this->filterService
+            ->expects($this->once())
+            ->method('filterLocations')
+            ->with($this->equalTo($query))
+            ->will($this->returnValue(new SearchResult()));
+
+        $adapter = $this->getAdapter($query);
+        $adapter->getSlice(0, 25);
+    }
+
+    protected function getAdapter(Query $query)
+    {
+        return new FilterAdapter($query, $this->filterService);
+    }
+}

--- a/tests/lib/Unit/Pagination/Pagerfanta/FindAdapterTest.php
+++ b/tests/lib/Unit/Pagination/Pagerfanta/FindAdapterTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Tests\Unit\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Netgen\EzPlatformSiteApi\API\FindService;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\ContentSearchHitAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FindAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\Slice;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group pager
+ */
+class FindAdapterTest extends TestCase
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FindService|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $findService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->findService = $this->getMockBuilder(FindService::class)
+            ->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+    }
+
+    public function testGetNbResults()
+    {
+        $nbResults = 123;
+        $query = new Query(['limit' => 10]);
+        $countQuery = clone $query;
+        $countQuery->limit = 0;
+        $searchResult = new SearchResult(['totalCount' => $nbResults]);
+
+        $this->findService
+            ->expects($this->once())
+            ->method('findContent')
+            ->with($this->equalTo($countQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query);
+
+        $this->assertSame($nbResults, $adapter->getNbResults());
+        $this->assertSame($nbResults, $adapter->getNbResults());
+    }
+
+    public function testGetFacets()
+    {
+        $facets = ['facet', 'facet'];
+        $query = new Query(['limit' => 10]);
+        $countQuery = clone $query;
+        $countQuery->limit = 0;
+        $searchResult = new SearchResult(['facets' => $facets]);
+
+        $this->findService
+            ->expects($this->once())
+            ->method('findContent')
+            ->with($this->equalTo($countQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query);
+
+        $this->assertSame($facets, $adapter->getFacets());
+        $this->assertSame($facets, $adapter->getFacets());
+    }
+
+    public function testMaxScore()
+    {
+        $maxScore = 100;
+        $query = new Query(['limit' => 10]);
+        $countQuery = clone $query;
+        $countQuery->limit = 0;
+        $searchResult = new SearchResult(['maxScore' => $maxScore]);
+
+        $this->findService
+            ->expects($this->once())
+            ->method('findContent')
+            ->with($this->equalTo($countQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query);
+
+        $this->assertSame($maxScore, $adapter->getMaxScore());
+        $this->assertSame($maxScore, $adapter->getMaxScore());
+    }
+
+    public function testTimeIsNotSet()
+    {
+        $this->findService
+            ->expects($this->never())
+            ->method('findContent');
+
+        $adapter = $this->getAdapter(new Query());
+
+        $this->assertNull($adapter->getTime());
+        $this->assertNull($adapter->getTime());
+    }
+
+    public function testGetSlice()
+    {
+        $offset = 20;
+        $limit = 25;
+        $nbResults = 123;
+        $facets = ['facet', 'facet'];
+        $maxScore = 100;
+        $time = 256;
+        $query = new Query(['offset' => 5, 'limit' => 10]);
+        $searchQuery = clone $query;
+        $searchQuery->offset = $offset;
+        $searchQuery->limit = $limit;
+        $searchQuery->performCount = false;
+
+        $hits = [new SearchHit(['valueObject' => 'Content'])];
+        $searchResult = new SearchResult([
+            'searchHits' => $hits,
+            'totalCount' => $nbResults,
+            'facets' => $facets,
+            'maxScore' => $maxScore,
+            'time' => $time,
+        ]);
+
+        $this->findService
+            ->expects($this->once())
+            ->method('findContent')
+            ->with($this->equalTo($searchQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query);
+        $slice = $adapter->getSlice($offset, $limit);
+
+        $this->assertInstanceOf(Slice::class, $slice);
+        $this->assertSame($hits, $slice->getSearchHits());
+        $this->assertSame($nbResults, $adapter->getNbResults());
+        $this->assertSame($facets, $adapter->getFacets());
+        $this->assertSame($maxScore, $adapter->getMaxScore());
+        $this->assertSame($time, $adapter->getTime());
+    }
+
+    public function testLocationQuery()
+    {
+        $query = new LocationQuery(['performCount' => false]);
+
+        $this->findService
+            ->expects($this->once())
+            ->method('findLocations')
+            ->with($this->equalTo($query))
+            ->will($this->returnValue(new SearchResult()));
+
+        $adapter = $this->getAdapter($query);
+        $adapter->getSlice(0, 25);
+    }
+
+    protected function getAdapter(Query $query)
+    {
+        return new FindAdapter($query, $this->findService);
+    }
+}

--- a/tests/lib/Unit/Pagination/Pagerfanta/SliceTest.php
+++ b/tests/lib/Unit/Pagination/Pagerfanta/SliceTest.php
@@ -25,9 +25,10 @@ class SliceTest extends TestCase
     public function testArrayAccess()
     {
         $slice = $this->getSlice();
+        $iterator = $slice->getIterator();
 
-        $this->assertEquals('one', $slice[0]);
-        $this->assertEquals('two', $slice[1]);
+        $this->assertEquals('one', $iterator[0]);
+        $this->assertEquals('two', $iterator[1]);
     }
 
     public function testGetSearchHits()

--- a/tests/lib/Unit/Pagination/Pagerfanta/SliceTest.php
+++ b/tests/lib/Unit/Pagination/Pagerfanta/SliceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Netgen\EzPlatformSiteApi\Tests\Unit\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\Slice;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group pager
+ */
+class SliceTest extends TestCase
+{
+    public function testIteration()
+    {
+        $slice = $this->getSlice();
+
+        $this->assertCount(2, $slice);
+
+        foreach ($slice as $searchHit) {
+            $this->assertInternalType('string', $searchHit);
+        }
+    }
+
+    public function testArrayAccess()
+    {
+        $slice = $this->getSlice();
+
+        $this->assertEquals('one', $slice[0]);
+        $this->assertEquals('two', $slice[1]);
+    }
+
+    public function testGetSearchHits()
+    {
+        $slice = $this->getSlice();
+
+        $this->assertEquals(
+            $this->getSearchHits(),
+            $slice->getSearchHits()
+        );
+    }
+
+    protected function getSearchHits()
+    {
+        return [
+            new SearchHit(['valueObject' => 'one']),
+            new SearchHit(['valueObject' => 'two']),
+        ];
+    }
+
+    public function getSlice()
+    {
+        return new Slice($this->getSearchHits());
+    }
+}

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,3 +1,3 @@
 [PHP]
 
-memory_limit = 3G
+memory_limit = 4G


### PR DESCRIPTION
This implements new Pagerfanta adapters and deprecates existing ones.

With this change, when deprecations are removed we will have only two adapters, `FilterAdapter` and `FindAdapter`, using `FilterService` and `Findservice`. Location and Content search/filtering is dispatched through checking the type of the given query. New trait `PagerfantaTrait` is added, providing convenience methods `getFilterPager()` and `getFindPager()`. Existing trait `PagerfantaFindTrait` is deprecated.

Adapters return new `Slice` instance, which implements `IteratorAggregate` with `ArrayIterator` (same as returned by Pagerfanta) and also provides method `getSearchHits()`. With that, separate adapters for iterating over SearchHits and value objects contained in them are no longer needed.

They implement new `SearchResultExtras` interface, providing access to facets, max score and execution time.

Adapters are put in use for QueryTypes, in the `QueryExecutor` service.

All added deprecations are targeted for removal in `3.0`.