### PR TITLE
[2.5] Support for Section and ObjectState identifiers with QueryTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,24 @@
 
 ## Installation
 
-To install Site API simply add it as a dependency to your project:
+To install Site API first add it as a dependency to your project:
 
 ```sh
 composer require netgen/ezplatform-site-api:^2.4
+```
+
+Once Site API is installed, activate the bundle in `app/AppKernel.php` file by adding it to the `$bundles` array in `registerBundles()` method, together with other required bundles:
+
+```php
+public function registerBundles()
+{
+    ...
+
+    $bundles[] = new Netgen\Bundle\EzPlatformSiteApiBundle\NetgenEzPlatformSiteApiBundle();
+    $bundles[] = new Netgen\Bundle\EzPlatformSearchExtraLegacyBundle\NetgenEzPlatformSearchExtraBundle;
+
+    return $bundles;
+}
 ```
 
 That will provide you with public Site API services defined in the [container](lib/Resources/config/services.yml),

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "^6.0|^7.0"
+        "ezsystems/ezpublish-kernel": "^6.0|^7.0",
+        "netgen/ezplatform-search-extra": "^1.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",

--- a/lib/Core/Site/QueryType/Base.php
+++ b/lib/Core/Site/QueryType/Base.php
@@ -223,6 +223,8 @@ abstract class Base implements QueryType
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
         ]);
         $resolver->setDefaults([
             'sort' => [],
@@ -231,27 +233,29 @@ abstract class Base implements QueryType
         ]);
 
         $resolver->setAllowedTypes('content_type', ['string', 'array']);
-        $resolver->setAllowedValues(
-            'content_type',
-            function ($contentTypes) {
-                if (!is_array($contentTypes)) {
-                    return true;
-                }
-
-                foreach ($contentTypes as $contentType) {
-                    if (!is_string($contentType)) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-        );
-
+        $resolver->setAllowedTypes('section', ['string', 'array']);
         $resolver->setAllowedTypes('field', ['array']);
         $resolver->setAllowedTypes('limit', ['int']);
         $resolver->setAllowedTypes('offset', ['int']);
         $resolver->setAllowedTypes('publication_date', ['int', 'string', 'array']);
+        $resolver->setAllowedTypes('state', ['array']);
+
+        $identifierValuesCallback = function ($identifiers) {
+            if (!is_array($identifiers)) {
+                return true;
+            }
+
+            foreach ($identifiers as $identifier) {
+                if (!is_string($identifier)) {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
+        $resolver->setAllowedValues('content_type', $identifierValuesCallback);
+        $resolver->setAllowedValues('section', $identifierValuesCallback);
         $resolver->setAllowedValues(
             'publication_date',
             function ($dates) {
@@ -295,11 +299,13 @@ abstract class Base implements QueryType
                 case 'parent_location_id':
                 case 'priority':
                 case 'publication_date':
+                case 'section':
                 case 'subtree':
                 case 'visible':
                     $definitions = $this->getCriterionDefinitionResolver()->resolve($name, $value);
                     break;
                 case 'field':
+                case 'state':
                     $definitions = $this->getCriterionDefinitionResolver()->resolveTargets($name, $value);
                     break;
                 default:

--- a/lib/Core/Site/QueryType/CriteriaBuilder.php
+++ b/lib/Core/Site/QueryType/CriteriaBuilder.php
@@ -15,6 +15,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use InvalidArgumentException;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ObjectStateIdentifier;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SectionIdentifier;
 
 /**
  * @internal Do not depend on this service, it can be changed without warning.
@@ -77,6 +79,10 @@ final class CriteriaBuilder
                 return $this->buildPriority($definition);
             case 'publication_date':
                 return $this->buildDateMetadataCreated($definition);
+            case 'section':
+                return $this->buildSection($definition);
+            case 'state':
+                return $this->buildObjectState($definition);
             case 'subtree':
                 return $this->buildSubtree($definition);
             case 'visible':
@@ -204,6 +210,30 @@ final class CriteriaBuilder
             $definition->operator,
             $this->resolveTimeValues($definition->value)
         );
+    }
+
+    /**
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\QueryType\CriterionDefinition $definition
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SectionIdentifier
+     */
+    private function buildSection(CriterionDefinition $definition)
+    {
+        return new SectionIdentifier($definition->value);
+    }
+
+    /**
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\QueryType\CriterionDefinition $definition
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ObjectStateIdentifier
+     */
+    private function buildObjectState(CriterionDefinition $definition)
+    {
+        return new ObjectStateIdentifier($definition->target, $definition->value);
     }
 
     /**

--- a/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
@@ -36,6 +36,8 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Base/CustomQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/CustomQueryTypeTest.php
@@ -40,6 +40,8 @@ class CustomQueryTypeTest extends TestCase
                 'content_type',
                 'field',
                 'publication_date',
+                'section',
+                'state',
                 'sort',
                 'limit',
                 'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -37,6 +37,8 @@ class FetchTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
@@ -124,6 +124,8 @@ class AllTagFieldsTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
@@ -108,6 +108,8 @@ class ForwardFieldsTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
@@ -72,6 +72,8 @@ class ReverseFieldsTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
@@ -116,6 +116,8 @@ class TagFieldsTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/CriteriaBuilderTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/CriteriaBuilderTest.php
@@ -15,6 +15,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use InvalidArgumentException;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ObjectStateIdentifier;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SectionIdentifier;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\CriteriaBuilder;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\CriterionDefinition;
 use PHPUnit\Framework\TestCase;
@@ -66,6 +68,39 @@ class CriteriaBuilderTest extends TestCase
             [
                 [
                     new CriterionDefinition([
+                        'name' => 'section',
+                        'target' => null,
+                        'operator' => Operator::EQ,
+                        'value' => 'standard',
+                    ]),
+                ],
+                [
+                    new SectionIdentifier('standard'),
+                ],
+            ],
+            [
+                [
+                    new CriterionDefinition([
+                        'name' => 'section',
+                        'target' => null,
+                        'operator' => Operator::EQ,
+                        'value' => 'standard',
+                    ]),
+                    new CriterionDefinition([
+                        'name' => 'section',
+                        'target' => null,
+                        'operator' => Operator::IN,
+                        'value' => ['users', 'media'],
+                    ]),
+                ],
+                [
+                    new SectionIdentifier('standard'),
+                    new SectionIdentifier(['users', 'media']),
+                ],
+            ],
+            [
+                [
+                    new CriterionDefinition([
                         'name' => 'depth',
                         'target' => null,
                         'operator' => Operator::EQ,
@@ -87,6 +122,41 @@ class CriteriaBuilderTest extends TestCase
                 ],
                 [
                     new Field('title', Operator::EQ, 'Hello'),
+                ],
+            ],
+            [
+                [
+                    new CriterionDefinition([
+                        'name' => 'state',
+                        'target' => 'ez_lock',
+                        'operator' => Operator::EQ,
+                        'value' => 'locked',
+                    ]),
+                ],
+                [
+                    new ObjectStateIdentifier('ez_lock', 'locked'),
+                ],
+            ],
+            [
+                [
+                    new CriterionDefinition([
+                        'name' => 'not',
+                        'target' => null,
+                        'operator' => null,
+                        'value' => [
+                            new CriterionDefinition([
+                                'name' => 'state',
+                                'target' => 'ez_lock',
+                                'operator' => Operator::EQ,
+                                'value' => 'locked',
+                            ]),
+                        ],
+                    ]),
+                ],
+                [
+                    new LogicalNot(
+                        new ObjectStateIdentifier('ez_lock', 'locked')
+                    ),
                 ],
             ],
             [

--- a/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
@@ -56,6 +56,8 @@ class ChildrenTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
@@ -43,6 +43,8 @@ class FetchTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
@@ -87,6 +87,8 @@ class SiblingsTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
@@ -60,6 +60,8 @@ class SubtreeTest extends QueryTypeBaseTest
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',

--- a/tests/lib/Unit/Core/Site/QueryType/QueryTypeBaseTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/QueryTypeBaseTest.php
@@ -72,6 +72,8 @@ abstract class QueryTypeBaseTest extends TestCase
             'content_type',
             'field',
             'publication_date',
+            'section',
+            'state',
             'sort',
             'limit',
             'offset',


### PR DESCRIPTION
This implements support for Section and ObjectState identifiers with QueryTypes, through https://github.com/netgen/ezplatform-search-extra (still unreleased).