### PR TITLE
Use new FilterAdapter instead of deprecated LocationSearchFilterAdapter

### DIFF
--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -10,7 +10,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use Netgen\EzPlatformSiteApi\API\Values\Content as APIContent;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchFilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 
@@ -275,7 +275,7 @@ final class Content extends APIContent
     public function filterLocations($maxPerPage = 25, $currentPage = 1)
     {
         $pager = new Pagerfanta(
-            new LocationSearchFilterAdapter(
+            new FilterAdapter(
                 new LocationQuery([
                     'filter' => new LogicalAnd(
                         [

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -8,7 +8,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use Netgen\EzPlatformSiteApi\API\Values\ContentInfo as APIContentInfo;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchFilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
 use Pagerfanta\Pagerfanta;
 
 final class ContentInfo extends APIContentInfo
@@ -159,7 +159,7 @@ final class ContentInfo extends APIContentInfo
     public function filterLocations($maxPerPage = 25, $currentPage = 1)
     {
         $pager = new Pagerfanta(
-            new LocationSearchFilterAdapter(
+            new FilterAdapter(
                 new LocationQuery([
                     'filter' => new LogicalAnd(
                         [

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use Netgen\EzPlatformSiteApi\API\Values\Location as APILocation;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchFilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
 use Pagerfanta\Pagerfanta;
 
 final class Location extends APILocation
@@ -202,7 +202,7 @@ final class Location extends APILocation
         }
 
         $pager = new Pagerfanta(
-            new LocationSearchFilterAdapter(
+            new FilterAdapter(
                 new LocationQuery([
                     'filter' => new LogicalAnd($criteria),
                     'sortClauses' => $this->getSortClauses(),
@@ -238,7 +238,7 @@ final class Location extends APILocation
         }
 
         $pager = new Pagerfanta(
-            new LocationSearchFilterAdapter(
+            new FilterAdapter(
                 new LocationQuery([
                     'filter' => new LogicalAnd($criteria),
                     'sortClauses' => $this->getSortClauses(),

--- a/lib/Core/Site/Values/Node.php
+++ b/lib/Core/Site/Values/Node.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use Netgen\EzPlatformSiteApi\API\Values\Node as APINode;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\LocationSearchFilterAdapter;
+use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
 use Pagerfanta\Pagerfanta;
 
 final class Node extends APINode
@@ -149,7 +149,7 @@ final class Node extends APINode
         }
 
         $pager = new Pagerfanta(
-            new LocationSearchFilterAdapter(
+            new FilterAdapter(
                 new LocationQuery([
                     'filter' => new LogicalAnd($criteria),
                     'sortClauses' => $this->getSortClauses(),
@@ -185,7 +185,7 @@ final class Node extends APINode
         }
 
         $pager = new Pagerfanta(
-            new LocationSearchFilterAdapter(
+            new FilterAdapter(
                 new LocationQuery([
                     'filter' => new LogicalAnd($criteria),
                     'sortClauses' => $this->getSortClauses(),


### PR DESCRIPTION
Replaced the `LocationSearchFilterAdapter` with the new `FilterAdapter` in following Value objects:

- Content
- ContentInfo
- Location
- Node