### PR TITLE
Deprecate from ContentInfo

### DIFF
--- a/lib/API/Values/ContentInfo.php
+++ b/lib/API/Values/ContentInfo.php
@@ -37,6 +37,8 @@ abstract class ContentInfo extends ValueObject
     /**
      * Return an array of Locations, limited by optional $limit.
      *
+     * @deprecated since version 2.6, to be removed in 3.0. Use the same method on Content object instead.
+     *
      * @param int $limit
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
@@ -45,6 +47,8 @@ abstract class ContentInfo extends ValueObject
 
     /**
      * Return an array of Locations, limited by optional $maxPerPage and $currentPage.
+     *
+     * @deprecated since version 2.6, to be removed in 3.0. Use the same method on Content object instead.
      *
      * @param int $maxPerPage
      * @param int $currentPage

--- a/lib/API/Values/ContentInfo.php
+++ b/lib/API/Values/ContentInfo.php
@@ -30,7 +30,6 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $innerContentInfo
  * @property-read \eZ\Publish\API\Repository\Values\ContentType\ContentType $innerContentType
  * @property-read \Netgen\EzPlatformSiteApi\API\Values\Location|null $mainLocation
- * @property-read \Netgen\EzPlatformSiteApi\API\Values\Content $content
  */
 abstract class ContentInfo extends ValueObject
 {

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -153,11 +153,15 @@ final class ContentInfo extends APIContentInfo
 
     public function getLocations($limit = 25)
     {
+        @trigger_error('getContent() is deprecated since version 2.6 and will be removed in 3.0. Use the same method on Content object instead.', E_USER_DEPRECATED);
+
         return $this->filterLocations($limit)->getIterator();
     }
 
     public function filterLocations($maxPerPage = 25, $currentPage = 1)
     {
+        @trigger_error('getContent() is deprecated since version 2.6 and will be removed in 3.0. Use the same method on Content object instead.', E_USER_DEPRECATED);
+
         $pager = new Pagerfanta(
             new FilterAdapter(
                 new LocationQuery([

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -188,6 +188,8 @@ final class ContentInfo extends APIContentInfo
 
     private function getContent()
     {
+        @trigger_error('Accessing Content from ContentInfo is deprecated since version 2.6 and will be removed in 3.0. Use the Content object directly instead.', E_USER_DEPRECATED);
+
         if ($this->internalContent === null) {
             $this->internalContent = $this->site->getLoadService()->loadContent($this->id);
         }

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -153,14 +153,14 @@ final class ContentInfo extends APIContentInfo
 
     public function getLocations($limit = 25)
     {
-        @trigger_error('getContent() is deprecated since version 2.6 and will be removed in 3.0. Use the same method on Content object instead.', E_USER_DEPRECATED);
+        @trigger_error('getLocations() is deprecated since version 2.6 and will be removed in 3.0. Use the same method on Content object instead.', E_USER_DEPRECATED);
 
         return $this->filterLocations($limit)->getIterator();
     }
 
     public function filterLocations($maxPerPage = 25, $currentPage = 1)
     {
-        @trigger_error('getContent() is deprecated since version 2.6 and will be removed in 3.0. Use the same method on Content object instead.', E_USER_DEPRECATED);
+        @trigger_error('filterLocations() is deprecated since version 2.6 and will be removed in 3.0. Use the same method on Content object instead.', E_USER_DEPRECATED);
 
         $pager = new Pagerfanta(
             new FilterAdapter(


### PR DESCRIPTION
This deprecates the following from `ContentInfo`:

- method `getLocations()`
- method `filterLocations()`
- property `$content`

The reason is we kept `ContentInfo` only to make migration of vanilla templates easier. So it's really only a container of properties and can't be obtained otherwise than through aggregation in `Content` object (methods providing that exist, but are already deprecated). Also, deprecated methods already exist on `Content` object.

For those reasons `ContentInfo` should not provide the deprecated methods and properties. Properties `$mainLocation` and `$innerContentType` are kept as an exception, since properties `$mainLocationId` and `$contentTypeId` are already available there (and on Repository `ContentInfo`).