### PR TITLE
Use sudo() to (lazy) load innerContent

### DIFF
--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -364,7 +364,7 @@ final class Content extends APIContent
     {
         if ($this->innerContent === null) {
             $this->innerContent = $this->repository->sudo(
-                function() {
+                function(Repository $repository) {
                     return $this->contentService->loadContent(
                         $this->id,
                         [$this->languageCode],

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -363,10 +363,14 @@ final class Content extends APIContent
     private function getInnerContent()
     {
         if ($this->innerContent === null) {
-            $this->innerContent = $this->contentService->loadContent(
-                $this->id,
-                [$this->languageCode],
-                $this->innerVersionInfo->versionNo
+            $this->innerContent = $this->repository->sudo(
+                function() {
+                    return $this->contentService->loadContent(
+                        $this->id,
+                        [$this->languageCode],
+                        $this->innerVersionInfo->versionNo
+                    );
+                }
             );
         }
 


### PR DESCRIPTION
If Site API Content was loaded using `sudo()`, `Content::$innerContent` should also be accessible regardless of permissions.