### PR TITLE
[2.7] Add config access to query type language expressions

### DIFF
--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\QueryType;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -19,11 +20,18 @@ final class ParameterProcessor
     private $requestStack;
 
     /**
-     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     * @var  \eZ\Publish\Core\MVC\ConfigResolverInterface
      */
-    public function __construct(RequestStack $requestStack)
+    private $configResolver;
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     */
+    public function __construct(RequestStack $requestStack, ConfigResolverInterface $configResolver)
     {
         $this->requestStack = $requestStack;
+        $this->configResolver = $configResolver;
     }
 
     /**
@@ -53,6 +61,7 @@ final class ParameterProcessor
                 'location' => $view->getSiteLocation(),
                 'content' => $view->getSiteContent(),
                 'request' => $this->requestStack->getCurrentRequest(),
+                'configResolver' => $this->configResolver,
             ]
         );
     }

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -66,8 +66,8 @@ final class ParameterProcessor
     {
         $expressionLanguage->register(
             'viewParam',
-            function () {},
-            function ($arguments, $name, $default) {
+            static function () {},
+            static function ($arguments, $name, $default) {
                 /** @var \Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView $view */
                 $view = $arguments['view'];
 
@@ -81,8 +81,8 @@ final class ParameterProcessor
 
         $expressionLanguage->register(
             'queryParam',
-            function () {},
-            function ($arguments, $name, $default) {
+            static function () {},
+            static function ($arguments, $name, $default) {
                 /** @var \Symfony\Component\HttpFoundation\Request $request */
                 $request = $arguments['request'];
 
@@ -92,8 +92,8 @@ final class ParameterProcessor
 
         $expressionLanguage->register(
             'timestamp',
-            function () {},
-            function ($arguments, $timeString) {
+            static function () {},
+            static function ($arguments, $timeString) {
                 return strtotime($timeString);
             }
         );

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -106,5 +106,19 @@ final class ParameterProcessor
                 return strtotime($timeString);
             }
         );
+
+        $configResolver = $this->configResolver;
+
+        $expressionLanguage->register(
+            'config',
+            static function () {},
+            static function ($arguments, $name, $default, $namespace = null, $scope = null) use ($configResolver) {
+                if ($configResolver->hasParameter($name, $namespace, $scope)) {
+                    return $configResolver->getParameter($name, $namespace, $scope);
+                }
+
+                return $default;
+            }
+        );
     }
 }

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -112,7 +112,7 @@ final class ParameterProcessor
         $expressionLanguage->register(
             'config',
             static function () {},
-            static function ($arguments, $name, $default, $namespace = null, $scope = null) use ($configResolver) {
+            static function ($arguments, $name, $default = null, $namespace = null, $scope = null) use ($configResolver) {
                 if ($configResolver->hasParameter($name, $namespace, $scope)) {
                     return $configResolver->getParameter($name, $namespace, $scope);
                 }

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -112,12 +112,8 @@ final class ParameterProcessor
         $expressionLanguage->register(
             'config',
             static function () {},
-            static function ($arguments, $name, $default = null, $namespace = null, $scope = null) use ($configResolver) {
-                if ($configResolver->hasParameter($name, $namespace, $scope)) {
-                    return $configResolver->getParameter($name, $namespace, $scope);
-                }
-
-                return $default;
+            static function ($arguments, $name, $namespace = null, $scope = null) use ($configResolver) {
+                return $configResolver->getParameter($name, $namespace, $scope);
             }
         );
     }

--- a/docs/reference/query_types.rst
+++ b/docs/reference/query_types.rst
@@ -325,7 +325,7 @@ Templating
 
 Configured queries will be available in Twig templates, through ``ng_query`` or ``ng_raw_query``.
 The difference it that the former will return a ``Pagerfanta`` instance, while the latter will
-return an instance of ``SerachResult``. That also means ``ng_query`` will use ``max_per_page`` and
+return an instance of ``SearchResult``. That also means ``ng_query`` will use ``max_per_page`` and
 ``page`` parameters to configure the pager, while ``ng_raw_query`` ignores them and executes the
 configured query directly.
 

--- a/docs/reference/query_types.rst
+++ b/docs/reference/query_types.rst
@@ -216,6 +216,28 @@ will be available in expression:
                         content_type: '@=location.contentInfo.contentTypeIdentifier'
                         sort: 'published desc'
 
+- eZ Platform ConfigResolver service as ``configResolver``
+
+    You can access dynamic configuration through eZ Platform's ``ConfigResolver`` service, enabling different query configuration per siteaccess.
+    For example maximum items per page:
+
+    .. code-block:: yaml
+
+        ngsite.eng.max_per_page: 10 # limit to 10 items on English siteaccess
+        ngsite.jpn.max_per_page: 20 # and 20 items on Japanese siteaccess
+
+    .. code-block:: yaml
+
+        ...
+            ng_named_query:
+                children:
+                    query_type: 'SiteAPI:Location/Children'
+                    max_per_page: '@=configResolver.getParameter("max_per_page", "ngsite")'
+                    page: 1
+                    parameters:
+                        content_type: 'article'
+                        sort: 'published desc'
+
 Several functions are also available for use in expressions. Most of these are provided to access
 the values described above in a more convenient way:
 
@@ -253,7 +275,6 @@ the values described above in a more convenient way:
                         content_type: 'article'
                         sort: 'published desc'
 
-
 - ``timestamp(value)``
 
     This function is used to get a timestamp value, typically used to define time conditions on the
@@ -272,6 +293,27 @@ the values described above in a more convenient way:
                         field:
                             start_date:
                                 gt: '@=timestamp("today")'
+
+- ``config(name, namespace = null, scope = null)``
+
+    This function is just a shortcut to ``getParameter()`` method of ``ConfigResolver`` service, described above:
+
+    .. code-block:: yaml
+
+        ngsite.eng.max_per_page: 10 # limit to 10 items on English siteaccess
+        ngsite.jpn.max_per_page: 20 # and 20 items on Japanese siteaccess
+
+    .. code-block:: yaml
+
+        ...
+            ng_named_query:
+                children:
+                    query_type: 'SiteAPI:Location/Children'
+                    max_per_page: '@=config("max_per_page", "ngsite")'
+                    page: 1
+                    parameters:
+                        content_type: 'article'
+                        sort: 'published desc'
 
 .. note::
 

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -195,27 +195,22 @@ class ParameterProcessorTest extends TestCase
     protected function getViewMock()
     {
         $viewMock = $this->getMockBuilder(ContentView::class)->getMock();
+
         $viewMock
-            ->expects($this->any())
             ->method('hasParameter')
             ->willReturnMap([
                 ['paramExists', true],
                 ['paramDoesNotExists', false],
             ]);
+
         $viewMock
-            ->expects($this->any())
             ->method('getParameter')
             ->willReturnMap([
                 ['paramExists', 123],
             ]);
-        $viewMock
-            ->expects($this->any())
-            ->method('getSiteLocation')
-            ->willReturn('LOCATION');
-        $viewMock
-            ->expects($this->any())
-            ->method('getSiteContent')
-            ->willReturn('CONTENT');
+
+        $viewMock->method('getSiteLocation')->willReturn('LOCATION');
+        $viewMock->method('getSiteContent')->willReturn('CONTENT');
 
         return $viewMock;
     }

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -131,6 +131,10 @@ class ParameterProcessorTest extends TestCase
                 "@=config('four', 40)",
                 4,
             ],
+            [
+                "@=config('three')",
+                null,
+            ],
         ];
     }
 

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -116,24 +116,16 @@ class ParameterProcessorTest extends TestCase
                 false,
             ],
             [
-                "@=config('one', 10, 'namespace', 'scope')",
+                "@=config('one', 'namespace', 'scope')",
                 1,
             ],
             [
-                "@=config('two', 20, 'namespace', 'scope')",
+                "@=config('two', 'namespace', 'scope')",
                 2,
             ],
             [
-                "@=config('three', 30, 'namespace', 'scope')",
-                30,
-            ],
-            [
-                "@=config('four', 40)",
+                "@=config('four')",
                 4,
-            ],
-            [
-                "@=config('three')",
-                null,
             ],
         ];
     }

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -89,7 +89,7 @@ class ParameterProcessorTest extends TestCase
             ],
             [
                 "@=timestamp('10 September 2000 +5 days')",
-                '968968800',
+                968968800,
             ],
             [
                 "@=configResolver.getParameter('one', 'namespace', 'scope')",

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -2,6 +2,7 @@
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Tests\QueryType;
 
+use DateTime;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor;
 use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
@@ -43,8 +44,8 @@ class ParameterProcessorTest extends TestCase
                 [123],
             ],
             [
-                new \DateTime('@1'),
-                new \DateTime('@1'),
+                new DateTime('@1'),
+                new DateTime('@1'),
             ],
             [
                 "@=request.query.get('page')",

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -2,6 +2,7 @@
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Tests\QueryType;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor;
 use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
 use PHPUnit\Framework\TestCase;
@@ -89,6 +90,46 @@ class ParameterProcessorTest extends TestCase
                 "@=timestamp('10 September 2000 +5 days')",
                 '968968800',
             ],
+            [
+                "@=configResolver.getParameter('one', 'namespace', 'scope')",
+                1,
+            ],
+            [
+                "@=configResolver.getParameter('two', 'namespace', 'scope')",
+                2,
+            ],
+            [
+                "@=configResolver.getParameter('four')",
+                4,
+            ],
+            [
+                "@=configResolver.hasParameter('one', 'namespace', 'scope')",
+                true,
+            ],
+            [
+                "@=configResolver.hasParameter('two', 'namespace', 'scope')",
+                true,
+            ],
+            [
+                "@=configResolver.hasParameter('three', 'namespace', 'scope')",
+                false,
+            ],
+            [
+                "@=config('one', 10, 'namespace', 'scope')",
+                1,
+            ],
+            [
+                "@=config('two', 20, 'namespace', 'scope')",
+                2,
+            ],
+            [
+                "@=config('three', 30, 'namespace', 'scope')",
+                30,
+            ],
+            [
+                "@=config('four', 40)",
+                4,
+            ],
         ];
     }
 
@@ -114,7 +155,40 @@ class ParameterProcessorTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['page' => 422]));
 
-        return new ParameterProcessor($requestStack);
+        $configResolver = $this->getConfigResolverMock();
+
+        return new ParameterProcessor($requestStack, $configResolver);
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    protected function getConfigResolverMock()
+    {
+        $configResolverMock = $this->getMockBuilder(ConfigResolverInterface::class)->getMock();
+
+        $getParameterMap = [
+            ['one', 'namespace', 'scope', 1],
+            ['two', 'namespace', 'scope', 2],
+            ['four', null, null, 4],
+        ];
+
+        $configResolverMock
+            ->method('getParameter')
+            ->willReturnMap($getParameterMap);
+
+        $hasParameterMap = [
+            ['one', 'namespace', 'scope', true],
+            ['two', 'namespace', 'scope', true],
+            ['three', 'namespace', 'scope', false],
+            ['four', null, null, true],
+        ];
+
+        $configResolverMock
+            ->method('hasParameter')
+            ->willReturnMap($hasParameterMap);
+
+        return $configResolverMock;
     }
 
     protected function getViewMock()

--- a/tests/bundle/QueryType/QueryDefinitionMapperTest.php
+++ b/tests/bundle/QueryType/QueryDefinitionMapperTest.php
@@ -2,6 +2,7 @@
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Tests\QueryType;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\QueryType\QueryType;
 use eZ\Publish\Core\QueryType\QueryTypeRegistry;
 use InvalidArgumentException;
@@ -258,8 +259,10 @@ class QueryDefinitionMapperTest extends TestCase
     {
         /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
         $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
+        /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolverMock */
+        $configResolverMock = $this->getMockBuilder(ConfigResolverInterface::class)->getMock();
 
-        return new ParameterProcessor($requestStack);
+        return new ParameterProcessor($requestStack, $configResolverMock);
     }
 
     /**

--- a/tests/bundle/QueryType/QueryDefinitionMapperTest.php
+++ b/tests/bundle/QueryType/QueryDefinitionMapperTest.php
@@ -217,7 +217,6 @@ class QueryDefinitionMapperTest extends TestCase
     {
         $queryTypeRegistryMock = $this->getMockBuilder(QueryTypeRegistry::class)->getMock();
         $queryTypeRegistryMock
-            ->expects($this->any())
             ->method('getQueryType')
             ->willReturnMap([
                 ['query_type', $this->getQueryTypeMock()],
@@ -242,7 +241,6 @@ class QueryDefinitionMapperTest extends TestCase
     {
         $queryTypeMock = $this->getMockBuilder(SiteQueryType::class)->getMock();
         $queryTypeMock
-            ->expects($this->any())
             ->method('supportsParameter')
             ->willReturnMap([
                 ['content', true],
@@ -271,14 +269,9 @@ class QueryDefinitionMapperTest extends TestCase
     protected function getViewMock()
     {
         $viewMock = $this->getMockBuilder(ContentView::class)->getMock();
-        $viewMock
-            ->expects($this->any())
-            ->method('getSiteLocation')
-            ->willReturn('location');
-        $viewMock
-            ->expects($this->any())
-            ->method('getSiteContent')
-            ->willReturn('content');
+
+        $viewMock->method('getSiteLocation')->willReturn('location');
+        $viewMock->method('getSiteContent')->willReturn('content');
 
         return $viewMock;
     }


### PR DESCRIPTION
This adds `ConfigResolver` and new `config()` method to the QueryType language expressions.
Method is a shortcut to `ConfigResolver` with default value fallback, with signature:

```
config($name, $namespace = null, $scope = null)
```

Example usage:

```yaml
queries:
    subtree:
        query_type: 'SiteAPI:Location/Children'
        max_per_page: '@=configResolver.getParameter("limit", "ngsite", "eng")'
        page: 1
        parameters:
            content_type: '@=config("content_types", "ngsite")'
```

### Todos
- [x] update docs