### PR TITLE
[2.7] Define type casting query param getters

### DIFF
--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -100,6 +100,66 @@ final class ParameterProcessor
         );
 
         $expressionLanguage->register(
+            'queryParamString',
+            static function () {},
+            static function ($arguments, $name, $default) {
+                /** @var \Symfony\Component\HttpFoundation\Request $request */
+                $request = $arguments['request'];
+
+                if ($request->query->has($name)) {
+                    return (string)$request->query->get($name, $default);
+                }
+
+                return $default;
+            }
+        );
+
+        $expressionLanguage->register(
+            'queryParamInt',
+            static function () {},
+            static function ($arguments, $name, $default) {
+                /** @var \Symfony\Component\HttpFoundation\Request $request */
+                $request = $arguments['request'];
+
+                if ($request->query->has($name)) {
+                    return (int)$request->query->get($name, $default);
+                }
+
+                return $default;
+            }
+        );
+
+        $expressionLanguage->register(
+            'queryParamFloat',
+            static function () {},
+            static function ($arguments, $name, $default) {
+                /** @var \Symfony\Component\HttpFoundation\Request $request */
+                $request = $arguments['request'];
+
+                if ($request->query->has($name)) {
+                    return (float)$request->query->get($name, $default);
+                }
+
+                return $default;
+            }
+        );
+
+        $expressionLanguage->register(
+            'queryParamBool',
+            static function () {},
+            static function ($arguments, $name, $default) {
+                /** @var \Symfony\Component\HttpFoundation\Request $request */
+                $request = $arguments['request'];
+
+                if ($request->query->has($name)) {
+                    return (bool)$request->query->get($name, $default);
+                }
+
+                return $default;
+            }
+        );
+
+        $expressionLanguage->register(
             'timestamp',
             static function () {},
             static function ($arguments, $timeString) {

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -122,7 +122,7 @@ final class ParameterProcessor
                 $request = $arguments['request'];
 
                 if ($request->query->has($name)) {
-                    return (int)$request->query->get($name, $default);
+                    return $request->query->getInt($name, $default);
                 }
 
                 return $default;
@@ -152,7 +152,7 @@ final class ParameterProcessor
                 $request = $arguments['request'];
 
                 if ($request->query->has($name)) {
-                    return (bool)$request->query->get($name, $default);
+                    return $request->query->getBoolean($name, $default);
                 }
 
                 return $default;

--- a/docs/reference/query_types.rst
+++ b/docs/reference/query_types.rst
@@ -261,7 +261,7 @@ the values described above in a more convenient way:
 
 - ``queryParam(name, default)``
 
-    This function is just a shortcut to ``GET`` parameters on the Request object:
+    This function is just a shortcut to ``GET`` / query string parameters on the Request object:
 
     .. code-block:: yaml
 
@@ -274,6 +274,26 @@ the values described above in a more convenient way:
                     parameters:
                         content_type: 'article'
                         sort: 'published desc'
+
+    Query string parameters accessed through the Request object will always be of the ``string`` type,
+    which can be a problem if you need to use them for configuration that expects a different scalar type.
+    For that reason separate type-casting getter functions are also provided:
+
+    - ``queryParamInt(name, default)``
+
+        Performs type casting of the found value to ``integer`` type.
+
+    - ``queryParamBool(name, default)``
+
+        Performs type casting of the found value to ``boolean`` type.
+
+    - ``queryParamFloat(name, default)``
+
+        Performs type casting of the found value to ``float`` type.
+
+    - ``queryParamString(name, default)``
+
+        Performs type casting of the found value to ``string`` type.
 
 - ``timestamp(value)``
 

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -14,6 +14,8 @@ class ParameterProcessorTest extends TestCase
 {
     public function providerForTestProcess()
     {
+        $date = new DateTime('@1');
+
         return [
             [
                 null,
@@ -44,8 +46,8 @@ class ParameterProcessorTest extends TestCase
                 [123],
             ],
             [
-                new DateTime('@1'),
-                new DateTime('@1'),
+                $date,
+                $date,
             ],
             [
                 "@=request.query.get('page')",
@@ -127,6 +129,42 @@ class ParameterProcessorTest extends TestCase
                 "@=config('four')",
                 4,
             ],
+            [
+                "@=queryParamInt('integerStringValue', 5)",
+                10,
+            ],
+            [
+                "@=queryParamInt('nonExistent', 5)",
+                5,
+            ],
+            [
+                "@=queryParamBool('booleanStringValue', false)",
+                true,
+            ],
+            [
+                "@=queryParamBool('booleanStringValue2', true)",
+                false,
+            ],
+            [
+                "@=queryParamBool('nonExistent', true)",
+                true,
+            ],
+            [
+                "@=queryParamFloat('floatStringValue', 7.7)",
+                5.7,
+            ],
+            [
+                "@=queryParamFloat('nonExistent', 7.7)",
+                7.7,
+            ],
+            [
+                "@=queryParamString('stringValue', 'yarn')",
+                'strand',
+            ],
+            [
+                "@=queryParamString('nonExistent', 'yarn')",
+                'yarn',
+            ],
         ];
     }
 
@@ -144,13 +182,22 @@ class ParameterProcessorTest extends TestCase
 
         $processedParameter = $parameterProcessor->process($parameter, $viewMock);
 
-        $this->assertEquals($expectedProcessedParameter, $processedParameter);
+        $this->assertSame($expectedProcessedParameter, $processedParameter);
     }
 
     protected function getParameterProcessorUnderTest()
     {
         $requestStack = new RequestStack();
-        $requestStack->push(new Request(['page' => 422]));
+        $requestStack->push(
+            new Request([
+                'page' => 422,
+                'integerStringValue' => '10',
+                'booleanStringValue' => 'true',
+                'booleanStringValue2' => '0',
+                'floatStringValue' => '5.7',
+                'stringValue' => 'strand',
+            ])
+        );
 
         $configResolver = $this->getConfigResolverMock();
 


### PR DESCRIPTION
Query/GET params, avilable through Symfony's Request object are always of string type. That can be a problem if you need to use them for QueryType conditions, which can be type hinted through `OptionResolver` component.

This adds type casting query param getter function for Query Type expression language:

- `queryParamString`
- `queryParamInt`
- `queryParamFloat`
- `queryParamBool`

Behavior is the same as with existing `queryParam` function, with the difference that value is casted to the appropriate scalar type. Usage example:

```yaml
...
    queries:
        children:
            query_type: 'SiteAPI:Location/Subtree'
            max_per_page: 10
            page: 1
            parameters:
                dapth: '@=queryParamInt("depth", 1)'
```

### Todos
- [x] tests
- [x] docs