### PR TITLE
[2.7] Implement query parameter allowed values

### DIFF
--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -91,23 +91,39 @@ final class ParameterProcessor
         $expressionLanguage->register(
             'queryParam',
             static function () {},
-            static function ($arguments, $name, $default) {
+            static function ($arguments, $name, $default, array $allowed = null) {
                 /** @var \Symfony\Component\HttpFoundation\Request $request */
                 $request = $arguments['request'];
 
-                return $request->query->get($name, $default);
+                if (!$request->query->has($name)) {
+                    return $default;
+                }
+
+                $value = $request->query->get($name);
+
+                if ($allowed === null || in_array($value, $allowed, true)) {
+                    return $value;
+                }
+
+                return $default;
             }
         );
 
         $expressionLanguage->register(
             'queryParamString',
             static function () {},
-            static function ($arguments, $name, $default) {
+            static function ($arguments, $name, $default, array $allowed = null) {
                 /** @var \Symfony\Component\HttpFoundation\Request $request */
                 $request = $arguments['request'];
 
-                if ($request->query->has($name)) {
-                    return (string)$request->query->get($name, $default);
+                if (!$request->query->has($name)) {
+                    return $default;
+                }
+
+                $value = (string)$request->query->get($name);
+
+                if ($allowed === null || in_array($value, $allowed, true)) {
+                    return $value;
                 }
 
                 return $default;
@@ -117,12 +133,18 @@ final class ParameterProcessor
         $expressionLanguage->register(
             'queryParamInt',
             static function () {},
-            static function ($arguments, $name, $default) {
+            static function ($arguments, $name, $default, array $allowed = null) {
                 /** @var \Symfony\Component\HttpFoundation\Request $request */
                 $request = $arguments['request'];
 
-                if ($request->query->has($name)) {
-                    return $request->query->getInt($name, $default);
+                if (!$request->query->has($name)) {
+                    return $default;
+                }
+
+                $value = $request->query->getInt($name);
+
+                if ($allowed === null || in_array($value, $allowed, true)) {
+                    return $value;
                 }
 
                 return $default;
@@ -132,12 +154,18 @@ final class ParameterProcessor
         $expressionLanguage->register(
             'queryParamFloat',
             static function () {},
-            static function ($arguments, $name, $default) {
+            static function ($arguments, $name, $default, array $allowed = null) {
                 /** @var \Symfony\Component\HttpFoundation\Request $request */
                 $request = $arguments['request'];
 
-                if ($request->query->has($name)) {
-                    return (float)$request->query->get($name, $default);
+                if (!$request->query->has($name)) {
+                    return $default;
+                }
+
+                $value = (float)$request->query->get($name);
+
+                if ($allowed === null || in_array($value, $allowed, true)) {
+                    return $value;
                 }
 
                 return $default;
@@ -147,12 +175,18 @@ final class ParameterProcessor
         $expressionLanguage->register(
             'queryParamBool',
             static function () {},
-            static function ($arguments, $name, $default) {
+            static function ($arguments, $name, $default, array $allowed = null) {
                 /** @var \Symfony\Component\HttpFoundation\Request $request */
                 $request = $arguments['request'];
 
-                if ($request->query->has($name)) {
-                    return $request->query->getBoolean($name, $default);
+                if (!$request->query->has($name)) {
+                    return $default;
+                }
+
+                $value = $request->query->getBoolean($name);
+
+                if ($allowed === null || in_array($value, $allowed, true)) {
+                    return $value;
                 }
 
                 return $default;

--- a/docs/reference/query_types.rst
+++ b/docs/reference/query_types.rst
@@ -259,9 +259,12 @@ the values described above in a more convenient way:
                         content_type: 'article'
                         sort: 'published desc'
 
-- ``queryParam(name, default)``
+- ``queryParam(name, default, array allowed = null)``
 
-    This function is just a shortcut to ``GET`` / query string parameters on the Request object:
+    This function is a shortcut to ``GET`` / query string parameters on the Request object.
+    Through optional third parameter ``allowed`` you can define an array of allowed values. This can be
+    useful when you need to limit what is being passed through the query string. For example you can
+    use it to limit filtering by ContentType to articles and news items:
 
     .. code-block:: yaml
 
@@ -272,26 +275,26 @@ the values described above in a more convenient way:
                     max_per_page: 10
                     page: '@=queryParam("page", 1)'
                     parameters:
-                        content_type: 'article'
+                        content_type: '@=queryParam("type", "article", ["article", "news"])'
                         sort: 'published desc'
 
     Query string parameters accessed through the Request object will always be of the ``string`` type,
     which can be a problem if you need to use them for configuration that expects a different scalar type.
     For that reason separate type-casting getter functions are also provided:
 
-    - ``queryParamInt(name, default)``
+    - ``queryParamInt(name, default, array allowed = null)``
 
         Performs type casting of the found value to ``integer`` type.
 
-    - ``queryParamBool(name, default)``
+    - ``queryParamBool(name, default, array allowed = null)``
 
         Performs type casting of the found value to ``boolean`` type.
 
-    - ``queryParamFloat(name, default)``
+    - ``queryParamFloat(name, default, array allowed = null)``
 
         Performs type casting of the found value to ``float`` type.
 
-    - ``queryParamString(name, default)``
+    - ``queryParamString(name, default, allowed = [])``
 
         Performs type casting of the found value to ``string`` type.
 

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -165,6 +165,66 @@ class ParameterProcessorTest extends TestCase
                 "@=queryParamString('nonExistent', 'yarn')",
                 'yarn',
             ],
+            [
+                "@=queryParam('page', 10, [10, 25, 50])",
+                10,
+            ],
+            [
+                "@=queryParam('page', '11', [10, 25, 50])",
+                '11',
+            ],
+            [
+                "@=queryParam('twentyFive', 10, [10, 25, 50])",
+                25,
+            ],
+            [
+                "@=queryParamInt('integerStringValue', 25, [10, 25, 50])",
+                10,
+            ],
+            [
+                "@=queryParamInt('integerStringValue', '11', [25, 50])",
+                '11',
+            ],
+            [
+                "@=queryParamInt('integerStringValue', 10, [10, 50])",
+                10,
+            ],
+            [
+                "@=queryParamBool('booleanStringValue', false, [true, false])",
+                true,
+            ],
+            [
+                "@=queryParamBool('booleanStringValue', true, [false])",
+                true,
+            ],
+            [
+                "@=queryParamBool('booleanStringValue', 5, [false])",
+                5,
+            ],
+            [
+                "@=queryParamFloat('floatStringValue', 7.7, [5.7, 7.8])",
+                5.7,
+            ],
+            [
+                "@=queryParamFloat('floatStringValue', 7.7, [5.6, 7.8])",
+                7.7,
+            ],
+            [
+                "@=queryParamFloat('floatStringValue', 'seven', [5.6, 7.8])",
+                'seven',
+            ],
+            [
+                "@=queryParamString('stringValue', 'and', ['hand'])",
+                'and',
+            ],
+            [
+                "@=queryParamString('stringValue', 5, ['hand', 'bland'])",
+                5,
+            ],
+            [
+                "@=queryParamString('stringValue', 'and', ['hand', 'strand'])",
+                'strand',
+            ],
         ];
     }
 
@@ -191,6 +251,7 @@ class ParameterProcessorTest extends TestCase
         $requestStack->push(
             new Request([
                 'page' => 422,
+                'twentyFive' => 25,
                 'integerStringValue' => '10',
                 'booleanStringValue' => 'true',
                 'booleanStringValue2' => '0',


### PR DESCRIPTION
Through `ExpressionLanguage` component we can access query/GET parameters to configure a query type. These go directly to the query type config and no control over validation/normalization is provided. Since these usually come from user input and can be manipulated by the user, that can be a problem.

Simple solution to this is providing a way to define allowed values with fallback to the default value:

```
queryParamInt('limit', 10, [10, 25, 50])
```

In this example, providing a limit value of 100, which is not among allowed values (10, 25, 50) would result in defaulting to 10.