### PR TITLE
[2.7] Support IsEmptyField criterion in Query Types

### DIFF
--- a/docs/reference/query_types/content_fetch.rst
+++ b/docs/reference/query_types/content_fetch.rst
@@ -8,7 +8,8 @@ This Query Type is used to build general purpose Location queries.
 +-------------+------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
-| conditions  | - `publication_date`_                                                        |
+| conditions  | - `is_field_empty`_                                                          |
+|             | - `publication_date`_                                                        |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/content_relations_all_tag_fields.rst
+++ b/docs/reference/query_types/content_relations_all_tag_fields.rst
@@ -21,7 +21,8 @@ of a given Content.
 +-------------+------------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                                  |
 | Content     | - `field`_                                                                         |
-| conditions  | - `publication_date`_                                                              |
+| conditions  | - `is_field_empty`_                                                                |
+|             | - `publication_date`_                                                              |
 |             | - `section`_                                                                       |
 |             | - `state`_                                                                         |
 +-------------+------------------------------------------------------------------------------------+

--- a/docs/reference/query_types/content_relations_forward_fields.rst
+++ b/docs/reference/query_types/content_relations_forward_fields.rst
@@ -11,7 +11,8 @@ This Query Type is used to build fetch Content that is related to from relation 
 +-------------+----------------------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                                            |
 | Content     | - `field`_                                                                                   |
-| conditions  | - `publication_date`_                                                                        |
+| conditions  | - `is_field_empty`_                                                                          |
+|             | - `publication_date`_                                                                        |
 |             | - `section`_                                                                                 |
 |             | - `state`_                                                                                   |
 +-------------+----------------------------------------------------------------------------------------------+

--- a/docs/reference/query_types/content_relations_reverse_fields.rst
+++ b/docs/reference/query_types/content_relations_reverse_fields.rst
@@ -11,7 +11,8 @@ This Query Type is used to build fetch Content that relates to the given Content
 +-------------+----------------------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                                            |
 | Content     | - `field`_                                                                                   |
-| conditions  | - `publication_date`_                                                                        |
+| conditions  | - `is_field_empty`_                                                                          |
+|             | - `publication_date`_                                                                        |
 |             | - `section`_                                                                                 |
 |             | - `state`_                                                                                   |
 +-------------+----------------------------------------------------------------------------------------------+

--- a/docs/reference/query_types/content_relations_tag_fields.rst
+++ b/docs/reference/query_types/content_relations_tag_fields.rst
@@ -22,7 +22,8 @@ fields of a given Content.
 +-------------+------------------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                                        |
 | Content     | - `field`_                                                                               |
-| conditions  | - `publication_date`_                                                                    |
+| conditions  | - `is_field_empty`_                                                                      |
+|             | - `publication_date`_                                                                    |
 |             | - `section`_                                                                             |
 |             | - `state`_                                                                               |
 +-------------+------------------------------------------------------------------------------------------+

--- a/docs/reference/query_types/location_children.rst
+++ b/docs/reference/query_types/location_children.rst
@@ -15,7 +15,8 @@ This Query Type is used to build queries that fetch children Locations.
 +-------------+------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
-| conditions  | - `publication_date`_                                                        |
+| conditions  | - `is_field_empty`_                                                          |
+|             | - `publication_date`_                                                        |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/location_fetch.rst
+++ b/docs/reference/query_types/location_fetch.rst
@@ -15,7 +15,8 @@ This Query Type is used to build general purpose Location queries.
 +-------------+------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
-| conditions  | - `publication_date`_                                                        |
+| conditions  | - `is_field_empty`_                                                          |
+|             | - `publication_date`_                                                        |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/location_siblings.rst
+++ b/docs/reference/query_types/location_siblings.rst
@@ -15,7 +15,8 @@ This Query Type is used to build queries that fetch Location siblings.
 +-------------+------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
-| conditions  | - `publication_date`_                                                        |
+| conditions  | - `is_field_empty`_                                                          |
+|             | - `publication_date`_                                                        |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/location_subtree.rst
+++ b/docs/reference/query_types/location_subtree.rst
@@ -17,7 +17,8 @@ This Query Type is used to build queries that fetch from the Location subtree.
 +-------------+------------------------------------------------------------------------------+
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
-| conditions  | - `publication_date`_                                                        |
+| conditions  | - `is_field_empty`_                                                          |
+|             | - `publication_date`_                                                        |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/parameters/common/content/is_field_empty.rst.inc
+++ b/docs/reference/query_types/parameters/common/content/is_field_empty.rst.inc
@@ -1,0 +1,25 @@
+``is_field_empty``
+~~~~~~~~~~~~~~~~~~
+
+Defines conditions on whether the Content fields are empty or not.
+
+.. note::
+
+  ``IsEmptyField`` criterion is upported only by Solr search engine, so this condition can be
+  used only with the ``FindService``. In order to use it configure the query with parameter ``use_filter``
+  set to ``false``.
+
+- **value type**: ``boolean``
+- **value format**: ``single``
+- **operators**: ``eq``
+- **target**: ``string`` Field identifier
+- **required**: ``false``
+- **default**: not defined
+
+Examples:
+
+.. code-block:: yaml
+
+    is_field_empty:
+        image: false
+        video: true

--- a/docs/reference/query_types/parameters/common_content_parameters.rst.inc
+++ b/docs/reference/query_types/parameters/common_content_parameters.rst.inc
@@ -3,6 +3,7 @@ Common Content conditions
 
 .. include:: /reference/query_types/parameters/common/content/content_type.rst.inc
 .. include:: /reference/query_types/parameters/common/content/field.rst.inc
+.. include:: /reference/query_types/parameters/common/content/is_field_empty.rst.inc
 .. include:: /reference/query_types/parameters/common/content/publication_date.rst.inc
 .. include:: /reference/query_types/parameters/common/content/section.rst.inc
 .. include:: /reference/query_types/parameters/common/content/state.rst.inc

--- a/lib/Core/Site/QueryType/Base.php
+++ b/lib/Core/Site/QueryType/Base.php
@@ -222,6 +222,7 @@ abstract class Base implements QueryType
         $resolver->setDefined([
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',
@@ -235,6 +236,7 @@ abstract class Base implements QueryType
         $resolver->setAllowedTypes('content_type', ['string', 'array']);
         $resolver->setAllowedTypes('section', ['string', 'array']);
         $resolver->setAllowedTypes('field', ['array']);
+        $resolver->setAllowedTypes('is_field_empty', ['array']);
         $resolver->setAllowedTypes('limit', ['int']);
         $resolver->setAllowedTypes('offset', ['int']);
         $resolver->setAllowedTypes('publication_date', ['int', 'string', 'array']);
@@ -265,6 +267,18 @@ abstract class Base implements QueryType
 
                 foreach ($dates as $date) {
                     if (!is_int($date) && !is_string($date)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        );
+        $resolver->setAllowedValues(
+            'is_field_empty',
+            static function ($isEmptyMap) {
+                foreach ($isEmptyMap as $key => $value) {
+                    if (!is_string($key) || !is_bool($value)) {
                         return false;
                     }
                 }
@@ -306,6 +320,7 @@ abstract class Base implements QueryType
                     break;
                 case 'field':
                 case 'state':
+                case 'is_field_empty':
                     $definitions = $this->getCriterionDefinitionResolver()->resolveTargets($name, $value);
                     break;
                 default:

--- a/lib/Core/Site/QueryType/CriteriaBuilder.php
+++ b/lib/Core/Site/QueryType/CriteriaBuilder.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use InvalidArgumentException;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\IsFieldEmpty;
 use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ObjectStateIdentifier;
 use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SectionIdentifier;
 
@@ -87,6 +88,8 @@ final class CriteriaBuilder
                 return $this->buildSubtree($definition);
             case 'visible':
                 return $this->buildVisibility($definition);
+            case 'is_field_empty':
+                return $this->buildIsFieldEmpty($definition);
         }
 
         throw new InvalidArgumentException(
@@ -310,5 +313,19 @@ final class CriteriaBuilder
         $isVisible = $definition->value ? Visibility::VISIBLE : Visibility::HIDDEN;
 
         return new Visibility($isVisible);
+    }
+
+    /**
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\QueryType\CriterionDefinition $definition
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return null|IsFieldEmpty
+     */
+    private function buildIsFieldEmpty(CriterionDefinition $definition)
+    {
+        $value = $definition->value ? IsFieldEmpty::IS_EMPTY : IsFieldEmpty::IS_NOT_EMPTY;
+
+        return new IsFieldEmpty($definition->target, $value);
     }
 }

--- a/lib/Core/Site/QueryType/CriterionDefinitionResolver.php
+++ b/lib/Core/Site/QueryType/CriterionDefinitionResolver.php
@@ -101,7 +101,7 @@ final class CriterionDefinitionResolver
         $definitions = [];
 
         foreach ($map as $operator => $value) {
-            if ('not' === $operator) {
+            if ($operator === 'not') {
                 $definitions[] = $this->buildDefinition(
                     'not',
                     null,
@@ -181,7 +181,7 @@ final class CriterionDefinitionResolver
      */
     private function resolveOperator($symbol, $value)
     {
-        if (null === $symbol) {
+        if ($symbol === null) {
             return $this->getOperatorByValueType($value);
         }
 

--- a/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
@@ -10,6 +10,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\IsFieldEmpty;
 use Netgen\EzPlatformSiteApi\Tests\Unit\Core\Site\QueryType\QueryTypeBaseTest;
 
 /**
@@ -35,6 +36,7 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',
@@ -180,6 +182,24 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
                     ],
                 ]),
             ],
+            [
+                [
+                    'is_field_empty' => [
+                        'image' => false,
+                        'video' => true,
+                    ],
+                    'sort' => 'published desc',
+                ],
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new IsFieldEmpty('image', IsFieldEmpty::IS_NOT_EMPTY),
+                        new IsFieldEmpty('video', IsFieldEmpty::IS_EMPTY),
+                    ]),
+                    'sortClauses' => [
+                        new DatePublished(Query::SORT_DESC),
+                    ],
+                ]),
+            ],
         ];
     }
 
@@ -221,6 +241,18 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
                     'offset' => 'ten',
                 ],
             ],
+            [
+                [
+                    'is_field_empty' => [
+                        'field' => 'not empty',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'is_field_empty' => [true],
+                ],
+            ],
         ];
     }
 
@@ -233,7 +265,7 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
                         'like' => 5,
                     ],
                 ],
-            ]
+            ],
         ];
     }
 

--- a/tests/lib/Unit/Core/Site/QueryType/Base/CustomQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/CustomQueryTypeTest.php
@@ -39,6 +39,7 @@ class CustomQueryTypeTest extends TestCase
             [
                 'content_type',
                 'field',
+                'is_field_empty',
                 'publication_date',
                 'section',
                 'state',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -36,6 +36,7 @@ class FetchTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
@@ -123,6 +123,7 @@ class AllTagFieldsTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
@@ -107,6 +107,7 @@ class ForwardFieldsTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
@@ -71,6 +71,7 @@ class ReverseFieldsTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
@@ -115,6 +115,7 @@ class TagFieldsTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/CriteriaBuilderTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/CriteriaBuilderTest.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use InvalidArgumentException;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\IsFieldEmpty;
 use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ObjectStateIdentifier;
 use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SectionIdentifier;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\CriteriaBuilder;
@@ -362,6 +363,19 @@ class CriteriaBuilderTest extends TestCase
                             new Subtree(['/subroot/tree/', '/poplar/']),
                         ])
                     ),
+                ],
+            ],
+            [
+                [
+                    new CriterionDefinition([
+                        'name' => 'is_field_empty',
+                        'target' => 'video',
+                        'operator' => null,
+                        'value' => false,
+                    ]),
+                ],
+                [
+                    new IsFieldEmpty('video', IsFieldEmpty::IS_NOT_EMPTY),
                 ],
             ],
         ];

--- a/tests/lib/Unit/Core/Site/QueryType/CriterionDefinitionResolverTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/CriterionDefinitionResolverTest.php
@@ -771,6 +771,26 @@ class CriterionDefinitionResolverTest extends TestCase
                     ]),
                 ],
             ],
+            [
+                [
+                    'image' => true,
+                    'video' => false,
+                ],
+                [
+                    new CriterionDefinition([
+                        'name' => 'test',
+                        'target' => 'image',
+                        'operator' => Operator::EQ,
+                        'value' => true,
+                    ]),
+                    new CriterionDefinition([
+                        'name' => 'test',
+                        'target' => 'video',
+                        'operator' => Operator::EQ,
+                        'value' => false,
+                    ]),
+                ],
+            ],
         ];
     }
 

--- a/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
@@ -55,6 +55,7 @@ class ChildrenTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
@@ -42,6 +42,7 @@ class FetchTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
@@ -86,6 +86,7 @@ class SiblingsTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
@@ -59,6 +59,7 @@ class SubtreeTest extends QueryTypeBaseTest
         return [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',

--- a/tests/lib/Unit/Core/Site/QueryType/QueryTypeBaseTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/QueryTypeBaseTest.php
@@ -71,6 +71,7 @@ abstract class QueryTypeBaseTest extends TestCase
         $expectedParameters = [
             'content_type',
             'field',
+            'is_field_empty',
             'publication_date',
             'section',
             'state',


### PR DESCRIPTION
This adds support for `IsEmptyField` criterion with Query Types. Example usage:

```yaml
...
    queries:
        children:
            query_type: 'SiteAPI:Location/Children'
            max_per_page: 10
            page: '@=queryParamInt("page", 1)'
            use_filter: false
            parameters:
                content_type: 'article'
                is_field_empty:
                    image: false
                    video: true
                sort: 'published desc'
```

Note: since `IsEmptyField` criterion is supported only with Solr search engine, query needs to be configured with `use_filter: false`.