### PR TITLE
[2.7] Use Pagefanta base from ezplatform-search-extra

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "~5.6|~7.0",
         "ezsystems/ezpublish-kernel": "^6.0|^7.0",
-        "netgen/ezplatform-search-extra": "^1.5"
+        "netgen/ezplatform-search-extra": "^1.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",

--- a/lib/Core/Site/Pagination/Pagerfanta/BaseAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/BaseAdapter.php
@@ -8,6 +8,8 @@ use Netgen\EzPlatformSiteApi\Core\Site\Pagination\SearchResultExtras;
 use Pagerfanta\Adapter\AdapterInterface;
 
 /**
+ * @deprecated since version 2.7, to be removed in 3.0. Use BaseAdapter from netgen/ezplatform-search-extra instead.
+ *
  * Base Site API search adapter.
  */
 abstract class BaseAdapter implements AdapterInterface, SearchResultExtras
@@ -47,6 +49,11 @@ abstract class BaseAdapter implements AdapterInterface, SearchResultExtras
      */
     public function __construct(Query $query)
     {
+        @trigger_error(
+            'BaseAdapter is deprecated since version 2.7 and will be removed in 3.0. Use BaseAdapter from netgen/ezplatform-search-extra instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->query = $query;
     }
 

--- a/lib/Core/Site/Pagination/Pagerfanta/FilterAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/FilterAdapter.php
@@ -4,6 +4,7 @@ namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
 
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
+use Netgen\EzPlatformSearchExtra\Core\Pagination\Pagerfanta\BaseAdapter;
 use Netgen\EzPlatformSiteApi\API\FilterService;
 
 /**

--- a/lib/Core/Site/Pagination/Pagerfanta/FindAdapter.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/FindAdapter.php
@@ -4,6 +4,7 @@ namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta;
 
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
+use Netgen\EzPlatformSearchExtra\Core\Pagination\Pagerfanta\BaseAdapter;
 use Netgen\EzPlatformSiteApi\API\FindService;
 
 /**

--- a/lib/Core/Site/Pagination/Pagerfanta/Slice.php
+++ b/lib/Core/Site/Pagination/Pagerfanta/Slice.php
@@ -9,6 +9,8 @@ use IteratorAggregate;
 use RuntimeException;
 
 /**
+ * @deprecated since version 2.7, to be removed in 3.0. Use Slice from netgen/ezplatform-search-extra instead.
+ *
  * Implements IteratorAggregate with access to the array of the SearchHit instances
  * and aggregated ArrayIterator over values contained in them.
  */
@@ -21,6 +23,11 @@ final class Slice implements IteratorAggregate, ArrayAccess
 
     public function __construct(array $searchHits)
     {
+        @trigger_error(
+            'BaseAdapter is deprecated since version 2.7 and will be removed in 3.0. Use Slice from netgen/ezplatform-search-extra instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->searchHits = $searchHits;
     }
 

--- a/lib/Core/Site/Pagination/SearchResultExtras.php
+++ b/lib/Core/Site/Pagination/SearchResultExtras.php
@@ -3,6 +3,8 @@
 namespace Netgen\EzPlatformSiteApi\Core\Site\Pagination;
 
 /**
+ * @deprecated since version 2.7, to be removed in 3.0. Use SearchResultExtras from netgen/ezplatform-search-extra instead.
+ *
  * Defines access to extra information of the search query result.
  */
 interface SearchResultExtras

--- a/tests/lib/Unit/Pagination/Pagerfanta/FilterAdapterTest.php
+++ b/tests/lib/Unit/Pagination/Pagerfanta/FilterAdapterTest.php
@@ -6,10 +6,9 @@ use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Netgen\EzPlatformSearchExtra\Core\Pagination\Pagerfanta\Slice;
 use Netgen\EzPlatformSiteApi\API\FilterService;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\ContentSearchHitAdapter;
 use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\Slice;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/lib/Unit/Pagination/Pagerfanta/FindAdapterTest.php
+++ b/tests/lib/Unit/Pagination/Pagerfanta/FindAdapterTest.php
@@ -6,10 +6,9 @@ use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Netgen\EzPlatformSearchExtra\Core\Pagination\Pagerfanta\Slice;
 use Netgen\EzPlatformSiteApi\API\FindService;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\ContentSearchHitAdapter;
 use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FindAdapter;
-use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\Slice;
 use PHPUnit\Framework\TestCase;
 
 /**


### PR DESCRIPTION
This switches adapter implementation to use base implementation from https://github.com/netgen/ezplatform-search-extra, added in 1.8. Local implementation is here deprecated, to be removed in 3.0.