### PR TITLE
Cleanup after SiteAwareTrait

### DIFF
--- a/bundle/Controller/Controller.php
+++ b/bundle/Controller/Controller.php
@@ -3,6 +3,7 @@
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller as BaseController;
+use Netgen\EzPlatformSiteApi\API\Site;
 use Netgen\EzPlatformSiteApi\Core\Traits\PagerfantaTrait;
 use Netgen\EzPlatformSiteApi\Core\Traits\SearchResultExtractorTrait;
 
@@ -10,6 +11,14 @@ abstract class Controller extends BaseController
 {
     use SearchResultExtractorTrait;
     use PagerfantaTrait;
+
+    /**
+     * @return \Netgen\EzPlatformSiteApi\API\Site
+     */
+    protected function getSite(): Site
+    {
+        return $this->container->get('netgen.ezplatform_site.site');
+    }
 
     /**
      * Returns the root location object for current siteaccess configuration.

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -14,7 +14,6 @@ services:
         abstract: true
         calls:
             - [setContainer, ['@service_container']]
-            - [setSite, ['@netgen.ezplatform_site.core.site']]
 
     netgen.ezplatform_site.core.settings:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Core\Site\Settings

--- a/lib/Core/Traits/PagerfantaTrait.php
+++ b/lib/Core/Traits/PagerfantaTrait.php
@@ -3,6 +3,7 @@
 namespace Netgen\EzPlatformSiteApi\Core\Traits;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
+use Netgen\EzPlatformSiteApi\API\Site;
 use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
 use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FindAdapter;
 use Pagerfanta\Pagerfanta;
@@ -15,6 +16,11 @@ use Pagerfanta\Pagerfanta;
  */
 trait PagerfantaTrait
 {
+    /**
+     * @return \Netgen\EzPlatformSiteApi\API\Site
+     */
+    abstract protected function getSite(): Site;
+
     /**
      * Return Pagerfanta instance using FilterAdapter for the given $query.
      *


### PR DESCRIPTION
`SiteAwareTrait` was added in https://github.com/netgen/ezplatform-site-api/pull/52 with `PagerfantaFindTrait`. I think the better approach would have been if we just declared abstract `getSite()` in the trait. Now that `PagerfantaFindTrait` is removed and replaced by `PagerfantaTrait`, `SiteAwareTrait` is no longer used.

This PR reimplements `getSite()` in our base controller, adds abstract `getSite()` to `PagerfantaTrait` and removes call to `setSite()` in the abstract service definition.