### PR TITLE
Add missing logger to ImageRuntime

### DIFF
--- a/bundle/Resources/config/services/templating.yml
+++ b/bundle/Resources/config/services/templating.yml
@@ -26,6 +26,7 @@ services:
         # public: false
         arguments:
             - '@ezpublish.fieldType.ezimage.variation_service'
+            - '@?logger'
         tags:
             - { name: twig.runtime }
 


### PR DESCRIPTION
`ImageRuntime` (and previously `ImageExtension`) implemented optional logging, without aggregating logger instance. This fixes the problem by adding the logger through constructor.