### PR TITLE
ezpublish.api.repository service alias needs to be public

### DIFF
--- a/bundle/DependencyInjection/Compiler/AggregateRepositoryPass.php
+++ b/bundle/DependencyInjection/Compiler/AggregateRepositoryPass.php
@@ -69,5 +69,6 @@ class AggregateRepositoryPass implements CompilerPassInterface
         // 3. Overwrite eZ Platform's public top Repository alias
         // to aggregate Repository implementation
         $container->setAlias(static::$topEzRepositoryAliasId, static::$aggregateRepositoryId);
+        $container->getAlias(static::$topEzRepositoryAliasId)->setPublic(true);
     }
 }


### PR DESCRIPTION
Created on 2.7 since it applies to that branch too (to avoid deprecation warning)