### PR TITLE
Add default view matcher, configuring the view with fallback templates

### DIFF
--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -43,3 +43,18 @@ services:
             - [setContainer, ["@service_container"]]
             - [setMatchConfig, [$content_view$]]
         public: false
+
+    netgen.ezplatform_site.ngcontent_view_provider.default_configured:
+        class: eZ\Bundle\EzPublishCoreBundle\View\Provider\Configured
+        arguments: ["@netgen.ezplatform_site.ngcontent_view.default_matcher_factory"]
+        tags:
+            - {name: ezpublish.view_provider, type: 'Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView', priority: 90}
+        public: false
+
+    netgen.ezplatform_site.ngcontent_view.default_matcher_factory:
+        class: eZ\Bundle\EzPublishCoreBundle\Matcher\ServiceAwareMatcherFactory
+        arguments: ["@ezpublish.api.repository", 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
+        calls:
+            - [setContainer, ["@service_container"]]
+            - [setMatchConfig, [$content_view_defaults$]]
+        public: false


### PR DESCRIPTION
It turns out there is a view matcher in eZ that provides some default templates for rarely used view types like `embed-inline` and so on.

This configures the same view matcher for Site API specific view (`Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView`).

Otherwise, you would get an exception: `No view template was set to render the view with the 'embed-inline' view type. Check your view configuration.`

Tested on eZ kernel v8.