### PR TITLE
Implement hinted search result extraction methods

### DIFF
--- a/lib/Core/Traits/SearchResultExtractorTrait.php
+++ b/lib/Core/Traits/SearchResultExtractorTrait.php
@@ -6,6 +6,8 @@ namespace Netgen\EzPlatformSiteApi\Core\Traits;
 
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Netgen\EzPlatformSiteApi\API\Values\Content;
+use Netgen\EzPlatformSiteApi\API\Values\Location;
 
 /**
  * SearchResultExtractorTrait provides a way to extract value objects
@@ -27,6 +29,46 @@ trait SearchResultExtractorTrait
         return array_map(
             static function (SearchHit $searchHit) {
                 return $searchHit->valueObject;
+            },
+            $searchResult->searchHits
+        );
+    }
+
+    /**
+     * Extracts Content items from SearchResult.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
+     */
+    protected function extractContentItems(SearchResult $searchResult): array
+    {
+        return array_map(
+            static function (SearchHit $searchHit): Content {
+                /** @var \Netgen\EzPlatformSiteApi\API\Values\Content $content */
+                $content = $searchHit->valueObject;
+
+                return $content;
+            },
+            $searchResult->searchHits
+        );
+    }
+
+    /**
+     * Extracts Locations from SearchResult.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
+     */
+    protected function extractLocations(SearchResult $searchResult): array
+    {
+        return array_map(
+            static function (SearchHit $searchHit): Location {
+                /** @var \Netgen\EzPlatformSiteApi\API\Values\Location $location */
+                $location = $searchHit->valueObject;
+
+                return $location;
             },
             $searchResult->searchHits
         );

--- a/tests/lib/Integration/Traits/SearchResultExtractorStub.php
+++ b/tests/lib/Integration/Traits/SearchResultExtractorStub.php
@@ -16,8 +16,28 @@ class SearchResultExtractorStub
      *
      * @return \eZ\Publish\API\Repository\Values\ValueObject[]
      */
-    public function extract(SearchResult $searchResult): array
+    public function doExtractValueObjects(SearchResult $searchResult): array
     {
         return $this->extractValueObjects($searchResult);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     *
+     * @return \eZ\Publish\API\Repository\Values\ValueObject[]
+     */
+    public function doExtractContentItems(SearchResult $searchResult): array
+    {
+        return $this->extractContentItems($searchResult);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     *
+     * @return \eZ\Publish\API\Repository\Values\ValueObject[]
+     */
+    public function doExtractLocations(SearchResult $searchResult): array
+    {
+        return $this->extractLocations($searchResult);
     }
 }

--- a/tests/lib/Integration/Traits/SearchResultExtractorTraitTest.php
+++ b/tests/lib/Integration/Traits/SearchResultExtractorTraitTest.php
@@ -23,7 +23,7 @@ class SearchResultExtractorTraitTest extends BaseTest
         $this->stub = new SearchResultExtractorStub();
     }
 
-    public function testItExtractsValuesFromLocations(): void
+    public function testItExtractsValuesFromLocationSearchResult(): void
     {
         $locationIds = [5, 56];
         $findService = $this->getSite()->getFindService();
@@ -35,7 +35,7 @@ class SearchResultExtractorTraitTest extends BaseTest
 
         $searchResult = $findService->findLocations($query);
 
-        $locationValueObjects = $this->stub->extract($searchResult);
+        $locationValueObjects = $this->stub->doExtractValueObjects($searchResult);
 
         foreach ($locationValueObjects as $value) {
             $this->assertInstanceOf(Location::class, $value);
@@ -54,13 +54,13 @@ class SearchResultExtractorTraitTest extends BaseTest
 
         $searchResult = $findService->findLocations($query);
 
-        $locationValueObjects = $this->stub->extract($searchResult);
+        $locationValueObjects = $this->stub->doExtractValueObjects($searchResult);
 
         $this->assertIsArray($locationValueObjects);
         $this->assertEmpty($locationValueObjects);
     }
 
-    public function testItExtractsValuesFromContents(): void
+    public function testItExtractsValuesFromContentSearchResult(): void
     {
         $contentIds = [4, 54];
         $findService = $this->getSite()->getFindService();
@@ -72,7 +72,7 @@ class SearchResultExtractorTraitTest extends BaseTest
 
         $searchResult = $findService->findContent($query);
 
-        $contentValueObjects = $this->stub->extract($searchResult);
+        $contentValueObjects = $this->stub->doExtractValueObjects($searchResult);
 
         foreach ($contentValueObjects as $value) {
             $this->assertInstanceOf(Content::class, $value);
@@ -91,9 +91,87 @@ class SearchResultExtractorTraitTest extends BaseTest
 
         $searchResult = $findService->findContent($query);
 
-        $contentValueObjects = $this->stub->extract($searchResult);
+        $contentValueObjects = $this->stub->doExtractValueObjects($searchResult);
 
         $this->assertIsArray($contentValueObjects);
         $this->assertEmpty($contentValueObjects);
+    }
+
+    public function testItExtractsContentItemsFromContentSearchResult(): void
+    {
+        $contentIds = [4, 41];
+        $findService = $this->getSite()->getFindService();
+        $query = new Query(
+            [
+                'filter' => new Query\Criterion\ContentId($contentIds),
+            ]
+        );
+
+        $searchResult = $findService->findContent($query);
+
+        $contentValueObjects = $this->stub->doExtractContentItems($searchResult);
+
+        $this->assertCount(2, $contentValueObjects);
+
+        foreach ($contentValueObjects as $value) {
+            $this->assertInstanceOf(Content::class, $value);
+        }
+    }
+
+    public function testItExtractsContentItemsFromEmptyContentSearchResult(): void
+    {
+        $contentIds = [52];
+        $findService = $this->getSite()->getFindService();
+        $query = new Query(
+            [
+                'filter' => new Query\Criterion\ContentId($contentIds),
+            ]
+        );
+
+        $searchResult = $findService->findContent($query);
+
+        $contentValueObjects = $this->stub->doExtractContentItems($searchResult);
+
+        $this->assertIsArray($contentValueObjects);
+        $this->assertEmpty($contentValueObjects);
+    }
+
+    public function testItExtractsLocationsFromLocationSearchResult(): void
+    {
+        $locationIds = [5, 12];
+        $findService = $this->getSite()->getFindService();
+        $query = new LocationQuery(
+            [
+                'filter' => new Query\Criterion\LocationId($locationIds),
+            ]
+        );
+
+        $searchResult = $findService->findLocations($query);
+
+        $locationValueObjects = $this->stub->doExtractLocations($searchResult);
+
+        $this->assertCount(2, $locationValueObjects);
+
+        foreach ($locationValueObjects as $value) {
+            $this->assertInstanceOf(Location::class, $value);
+        }
+    }
+
+    public function testItExtractsLocationsFromEmptyLocationSearchResult(): void
+    {
+        $locationIds = [54];
+        $findService = $this->getSite()->getFindService();
+        $query = new LocationQuery(
+            [
+                'filter' => new Query\Criterion\LocationId($locationIds),
+            ]
+        );
+
+        $searchResult = $findService->findLocations($query);
+
+        $locationValueObjects = $this->stub->doExtractLocations($searchResult);
+
+        $this->assertIsArray($locationValueObjects);
+        $this->assertEmpty($locationValueObjects);
     }
 }


### PR DESCRIPTION
This implements two new type-hinted methods in `SearchResultExtractorTrait`:
- `extractContentItems()`
- `extractLocations()`