### PR TITLE
Declare that get Location methods on objects return arrays

### DIFF
--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -91,7 +91,7 @@ abstract class Content extends ValueObject
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
      */
-    abstract public function getLocations(int $limit = 25);
+    abstract public function getLocations(int $limit = 25): array;
 
     /**
      * Return an array of Locations, limited by optional $maxPerPage and $currentPage.
@@ -101,7 +101,7 @@ abstract class Content extends ValueObject
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]|\Pagerfanta\Pagerfanta Pagerfanta instance iterating over Site API Locations
      */
-    abstract public function filterLocations(int $maxPerPage = 25, int $currentPage = 1);
+    abstract public function filterLocations(int $maxPerPage = 25, int $currentPage = 1): Pagerfanta;
 
     /**
      * Return single related Content from $fieldDefinitionIdentifier field.

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -40,7 +40,7 @@ abstract class Location extends ValueObject
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
      */
-    abstract public function getChildren(int $limit = 25);
+    abstract public function getChildren(int $limit = 25): array;
 
     /**
      * Return an array of children Locations, filtered by optional
@@ -61,7 +61,7 @@ abstract class Location extends ValueObject
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Location[]
      */
-    abstract public function getSiblings(int $limit = 25);
+    abstract public function getSiblings(int $limit = 25): array;
 
     /**
      * Return an array of Location siblings, filtered by optional

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -275,9 +275,9 @@ final class Content extends APIContent
         return $this->getFieldById($id)->value;
     }
 
-    public function getLocations(int $limit = 25)
+    public function getLocations(int $limit = 25): array
     {
-        return $this->filterLocations($limit)->getIterator();
+        return $this->filterLocations($limit)->getIterator()->getArrayCopy();
     }
 
     public function filterLocations(int $maxPerPage = 25, int $currentPage = 1): Pagerfanta

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -189,9 +189,9 @@ final class Location extends APILocation
         ];
     }
 
-    public function getChildren(int $limit = 25)
+    public function getChildren(int $limit = 25): array
     {
-        return $this->filterChildren([], $limit)->getIterator();
+        return $this->filterChildren([], $limit)->getIterator()->getArrayCopy();
     }
 
     public function filterChildren(array $contentTypeIdentifiers = [], int $maxPerPage = 25, int $currentPage = 1): Pagerfanta
@@ -222,9 +222,9 @@ final class Location extends APILocation
         return $pager;
     }
 
-    public function getSiblings(int $limit = 25)
+    public function getSiblings(int $limit = 25): array
     {
-        return $this->filterSiblings([], $limit)->getIterator();
+        return $this->filterSiblings([], $limit)->getIterator()->getArrayCopy();
     }
 
     public function filterSiblings(array $contentTypeIdentifiers = [], int $maxPerPage = 25, int $currentPage = 1): Pagerfanta

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -123,7 +123,7 @@ class BaseTest extends APIBaseTest
         $this->assertInstanceOf(VersionInfo::class, $content->innerVersionInfo);
 
         $locations = $content->getLocations();
-        $this->assertInstanceOf(ArrayIterator::class, $locations);
+        $this->assertIsArray($locations);
         $this->assertCount(1, $locations);
         $this->assertInstanceOf(Location::class, reset($locations));
 

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -70,6 +70,8 @@ class BaseTest extends APIBaseTest
                     'isSurrogate' => false,
                 ],
             ],
+            'siblingLocationId' => 64,
+            'childLocationId' => 65,
         ];
     }
 
@@ -327,9 +329,20 @@ class BaseTest extends APIBaseTest
         $this->assertInstanceOf(APILocation::class, $location->innerLocation);
         $this->assertInstanceOf(Content::class, $location->content);
 
-        if ($location->parentLocationId !== 1) {
-            $this->assertInstanceOf(Location::class, $location->parent);
-        }
+        $this->assertInstanceOf(Location::class, $location->parent);
+        $this->assertEquals($parentLocationId, $location->parent->id);
+
+        $children = $location->getChildren();
+        $this->assertIsArray($children);
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Location::class, $children[0]);
+        $this->assertEquals($data['childLocationId'], $children[0]->id);
+
+        $siblings = $location->getSiblings();
+        $this->assertIsArray($siblings);
+        $this->assertCount(1, $siblings);
+        $this->assertInstanceOf(Location::class, $siblings[0]);
+        $this->assertEquals($data['siblingLocationId'], $siblings[0]->id);
 
         $this->assertTrue(isset($location->contentId));
         $this->assertTrue(isset($location->contentInfo));


### PR DESCRIPTION
Methods `Content::getLocations()`, `Location::getChildren()` and `Location::getSiblings()` were hinting to return an array, but were actually returning an instance if `ArrayIterator`. This updates the implementation to return an array and adds the `array` return type declaration.

Note that this is technically a BC break.

### To do
- [x] add test coverage