### PR TITLE
[3.0] As a developer I want to render Content view without using a subrequest

### DIFF
--- a/bundle/Resources/config/services/templating.yml
+++ b/bundle/Resources/config/services/templating.yml
@@ -13,7 +13,25 @@ services:
             - '@ezpublish.templating.field_block_renderer'
             - '@ezpublish.fieldType.parameterProviderRegistry'
         tags:
-            - {name: twig.runtime}
+            - { name: twig.runtime }
+
+    netgen.ezplatform_site.twig.extension.content_rendering:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ContentViewExtension
+        public: false
+        tags:
+            - { name: twig.extension }
+
+    netgen.ezplatform_site.twig.runtime.content_rendering:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ContentViewRuntime
+        # public: false
+        arguments:
+            - '@request_stack'
+            - '@controller_resolver'
+            - '@argument_resolver'
+            - '@netgen.ezplatform_site.view_builder.content'
+            - '@ezpublish.view.template_renderer'
+        tags:
+            - { name: twig.runtime }
 
     netgen.ezplatform_site.twig.extension.image:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension\ImageExtension

--- a/bundle/Templating/Twig/Extension/ContentViewExtension.php
+++ b/bundle/Templating/Twig/Extension/ContentViewExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Twig extension for content view rendering.
+ */
+class ContentViewExtension extends AbstractExtension
+{
+    /**
+     * @return \Twig\TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ng_view_content',
+                [ContentViewRuntime::class, 'renderContentView'],
+                ['is_safe' => ['html']]
+            ),
+        ];
+    }
+}

--- a/bundle/Templating/Twig/Extension/ContentViewExtension.php
+++ b/bundle/Templating/Twig/Extension/ContentViewExtension.php
@@ -13,6 +13,8 @@ use Twig\TwigFunction;
 class ContentViewExtension extends AbstractExtension
 {
     /**
+     * Note that this function is experimental. Please report any issues on https://github.com/netgen/ezplatform-site-api/issues
+     *
      * @return \Twig\TwigFunction[]
      */
     public function getFunctions(): array

--- a/bundle/Templating/Twig/Extension/ContentViewRuntime.php
+++ b/bundle/Templating/Twig/Extension/ContentViewRuntime.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Templating\Twig\Extension;
+
+use function call_user_func_array;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\View\Renderer;
+use LogicException;
+use Netgen\Bundle\EzPlatformSiteApiBundle\View\Builder\ContentViewBuilder;
+use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
+use Netgen\EzPlatformSiteApi\API\Values\Content;
+use Netgen\EzPlatformSiteApi\API\Values\Location;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Twig extension runtime for content rendering (view).
+ */
+class ContentViewRuntime
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var \Symfony\Component\HttpKernel\Controller\ControllerResolverInterface
+     */
+    private $controllerResolver;
+
+    /**
+     * @var \Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface
+     */
+    private $argumentResolver;
+
+    /**
+     * @var \Netgen\Bundle\EzPlatformSiteApiBundle\View\Builder\ContentViewBuilder
+     */
+    private $viewBuilder;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\View\Renderer
+     */
+    private $viewRenderer;
+
+    /**
+     * @var \Psr\Log\LoggerInterface|\Psr\Log\NullLogger|null
+     */
+    private $logger;
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     * @param \Symfony\Component\HttpKernel\Controller\ControllerResolverInterface $controllerResolver
+     * @param \Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface $argumentResolver
+     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\View\Builder\ContentViewBuilder $viewBuilder
+     * @param \eZ\Publish\Core\MVC\Symfony\View\Renderer $viewRenderer
+     * @param \Psr\Log\LoggerInterface|null $logger
+     */
+    public function __construct(
+        RequestStack $requestStack,
+        ControllerResolverInterface $controllerResolver,
+        ArgumentResolverInterface $argumentResolver,
+        ContentViewBuilder $viewBuilder,
+        Renderer $viewRenderer,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->requestStack = $requestStack;
+        $this->controllerResolver = $controllerResolver;
+        $this->argumentResolver = $argumentResolver;
+        $this->viewBuilder = $viewBuilder;
+        $this->viewRenderer = $viewRenderer;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Renders the HTML for a given $content.
+     *
+     * @param string $viewType
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $contentOrLocation
+     * @param array $parameters
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     * @throws \eZ\Publish\Core\Base\Exceptions\UnauthorizedException
+     *
+     * @return string The HTML markup
+     */
+    public function renderContentView(
+        string $viewType,
+        ValueObject $contentOrLocation,
+        array $parameters = []
+    ): string {
+        $this->logger->critical('Twig function "ng_view_content" is experimental. Please report any issues on https://github.com/netgen/ezplatform-site-api/issues');
+
+        $content = $this->getContent($contentOrLocation);
+
+        $view = $this->viewBuilder->buildView([
+            'viewType' => $viewType,
+            'content' => $content,
+            'location' => $this->getLocation($contentOrLocation),
+            '_controller' => 'ng_content:viewAction',
+        ]);
+
+        if (!$this->viewMatched($view)) {
+            throw new LogicException("Couldn't match view '{$viewType}' for Content #{$content->id}");
+        }
+
+        $view->addParameters($parameters);
+
+        $controllerReference = $view->getControllerReference();
+
+        if ($controllerReference === null || $controllerReference->controller === 'ng_content:viewAction') {
+            return $this->viewRenderer->render($view);
+        }
+
+        return $this->renderController($view, $controllerReference);
+    }
+
+    /**
+     * This is the only way to check if the view actually matched?
+     *
+     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView $contentView
+     *
+     * @return bool
+     */
+    private function viewMatched(ContentView $contentView): bool
+    {
+        return !empty($contentView->getConfigHash());
+    }
+
+    private function getContent(ValueObject $contentOrLocation): Content
+    {
+        if ($contentOrLocation instanceof Content) {
+            return $contentOrLocation;
+        }
+
+        if ($contentOrLocation instanceof Location) {
+            return $contentOrLocation->content;
+        }
+
+        throw new LogicException('Given value must be Content or Location instance.');
+    }
+
+    private function getLocation(ValueObject $contentOrLocation): ?Location
+    {
+        if ($contentOrLocation instanceof Location) {
+            return $contentOrLocation;
+        }
+
+        if ($contentOrLocation instanceof Content) {
+            return $contentOrLocation->mainLocation;
+        }
+
+        throw new LogicException('Given value must be Content or Location instance.');
+    }
+
+    private function renderController(ContentView $contentView, ControllerReference $controllerReference): string
+    {
+        $controller = $this->resolveController($controllerReference);
+        $arguments = $this->resolveControllerArguments($contentView, $controller);
+
+        $result = call_user_func_array($controller, $arguments);
+
+        if ($result instanceof ContentView) {
+            return $this->viewRenderer->render($result);
+        }
+
+        if ($result instanceof Response) {
+            return $result->getContent();
+        }
+
+        throw new LogicException('Controller result must be ContentView or Response instance');
+    }
+
+    private function resolveController(ControllerReference $controllerReference): callable
+    {
+        $controllerRequest = new Request();
+        $controllerRequest->attributes->set('_controller', $controllerReference->controller);
+        $controller = $this->controllerResolver->getController($controllerRequest);
+
+        if ($controller === false) {
+            throw new NotFoundHttpException(
+                sprintf('Unable to find the controller "%s".', $controllerReference->controller)
+            );
+        }
+
+        return $controller;
+    }
+
+    private function resolveControllerArguments(ContentView $contentView, callable $controller): array
+    {
+        $request = $this->requestStack->getMasterRequest();
+
+        if ($request === null) {
+            throw new LogicException('A Request must be available.');
+        }
+
+        $request = $request->duplicate();
+        $request->attributes->set('view', $contentView);
+
+        return $this->argumentResolver->getArguments($request, $controller);
+    }
+}

--- a/bundle/Templating/Twig/Extension/ContentViewRuntime.php
+++ b/bundle/Templating/Twig/Extension/ContentViewRuntime.php
@@ -76,8 +76,8 @@ class ContentViewRuntime
      *
      * Note that this is experimental. Please report any issues on https://github.com/netgen/ezplatform-site-api/issues
      *
-     * @param string $viewType
      * @param \eZ\Publish\API\Repository\Values\ValueObject $contentOrLocation
+     * @param string $viewType
      * @param array $parameters
      *
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
@@ -87,8 +87,8 @@ class ContentViewRuntime
      * @return string The HTML markup
      */
     public function renderContentView(
-        string $viewType,
         ValueObject $contentOrLocation,
+        string $viewType,
         array $parameters = []
     ): string {
         $content = $this->getContent($contentOrLocation);

--- a/bundle/Templating/Twig/Extension/ContentViewRuntime.php
+++ b/bundle/Templating/Twig/Extension/ContentViewRuntime.php
@@ -12,8 +12,6 @@ use Netgen\Bundle\EzPlatformSiteApiBundle\View\Builder\ContentViewBuilder;
 use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
 use Netgen\EzPlatformSiteApi\API\Values\Content;
 use Netgen\EzPlatformSiteApi\API\Values\Location;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -53,36 +51,30 @@ class ContentViewRuntime
     private $viewRenderer;
 
     /**
-     * @var \Psr\Log\LoggerInterface|\Psr\Log\NullLogger|null
-     */
-    private $logger;
-
-    /**
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
      * @param \Symfony\Component\HttpKernel\Controller\ControllerResolverInterface $controllerResolver
      * @param \Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface $argumentResolver
      * @param \Netgen\Bundle\EzPlatformSiteApiBundle\View\Builder\ContentViewBuilder $viewBuilder
      * @param \eZ\Publish\Core\MVC\Symfony\View\Renderer $viewRenderer
-     * @param \Psr\Log\LoggerInterface|null $logger
      */
     public function __construct(
         RequestStack $requestStack,
         ControllerResolverInterface $controllerResolver,
         ArgumentResolverInterface $argumentResolver,
         ContentViewBuilder $viewBuilder,
-        Renderer $viewRenderer,
-        ?LoggerInterface $logger = null
+        Renderer $viewRenderer
     ) {
         $this->requestStack = $requestStack;
         $this->controllerResolver = $controllerResolver;
         $this->argumentResolver = $argumentResolver;
         $this->viewBuilder = $viewBuilder;
         $this->viewRenderer = $viewRenderer;
-        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
      * Renders the HTML for a given $content.
+     *
+     * Note that this is experimental. Please report any issues on https://github.com/netgen/ezplatform-site-api/issues
      *
      * @param string $viewType
      * @param \eZ\Publish\API\Repository\Values\ValueObject $contentOrLocation
@@ -99,8 +91,6 @@ class ContentViewRuntime
         ValueObject $contentOrLocation,
         array $parameters = []
     ): string {
-        $this->logger->critical('Twig function "ng_view_content" is experimental. Please report any issues on https://github.com/netgen/ezplatform-site-api/issues');
-
         $content = $this->getContent($contentOrLocation);
 
         $view = $this->viewBuilder->buildView([


### PR DESCRIPTION
This implements experimental support for rendering Content views without executing a subrequest.

Performance impact of subrequests in production mode is not significant, but that is also not where developers spend most of their time. Because of the profiling, performance impact in debug mode can be huge. In one test we executed, a page with 40 subrequests that took ~3 seconds to render, needed only half as much when subrequests were replaced.

For most use cases it is not really necessary to render a view through a subrequest, and providing an alternative, more performant way is a chance to improve developer's experience.

**Note that this is not intended to be a complete replacement for subrequests, because it does not dispatch MVC events it can be safely used only for those views that do not depend on them. Also, it should be used only with configured views (`ngcontent_view` semantic configuration):**

```yaml
ezpublish:
    system:
        frontend_group:
            ngcontent_view:
                line:
                    article:
                        template: "@ezdesign/content/line/article.html.twig"
                        controller: custom_controller:viewAction
                        match:
                            Identifier\ContentType: article
```

Twig function `ng_view_content` will accept both Content and Location objects:

```twig
{{ ng_view_content(articleContent, 'line', {'name': 'value'} }}
{{ ng_view_content(articleLocation, 'line', {'name': 'value'} }}
```

Rendering a nonexistent view will intentionally result in a fatal error. That is different from how executing a subrequest behaves, where it will silently produce an empty string.

Custom controllers are also supported and that is probably the part that needs most testing.

### Todos
- [x] write some documentation