### PR TITLE
Allow defining content_type and section with explicit operators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
 branches:
     only:
         - master
+        - 2.7-release
 
 # make sure to update composer to latest available version
 before_install:

--- a/lib/Core/Site/QueryType/Base.php
+++ b/lib/Core/Site/QueryType/Base.php
@@ -242,21 +242,6 @@ abstract class Base implements QueryType
         $resolver->setAllowedTypes('publication_date', ['int', 'string', 'array']);
         $resolver->setAllowedTypes('state', ['array']);
 
-        $identifierValuesCallback = function ($identifiers) {
-            if (!is_array($identifiers)) {
-                return true;
-            }
-
-            foreach ($identifiers as $identifier) {
-                if (!is_string($identifier)) {
-                    return false;
-                }
-            }
-
-            return true;
-        };
-
-        $resolver->setAllowedValues('section', $identifierValuesCallback);
         $resolver->setAllowedValues(
             'publication_date',
             function ($dates) {

--- a/lib/Core/Site/QueryType/Base.php
+++ b/lib/Core/Site/QueryType/Base.php
@@ -256,7 +256,6 @@ abstract class Base implements QueryType
             return true;
         };
 
-        $resolver->setAllowedValues('content_type', $identifierValuesCallback);
         $resolver->setAllowedValues('section', $identifierValuesCallback);
         $resolver->setAllowedValues(
             'publication_date',

--- a/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
@@ -213,11 +213,6 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -201,11 +201,6 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -69,7 +69,9 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'content_type' => 'article',
+                    'content_type' => [
+                        'eq' => 'article',
+                    ],
                     'sort' => 'published desc',
                 ],
                 new Query([
@@ -81,14 +83,18 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'content_type' => 'article',
+                    'content_type' => [
+                        'in' => [
+                            'article',
+                        ],
+                    ],
                     'field' => [],
                     'sort' => [
                         'published asc',
                     ],
                 ],
                 new Query([
-                    'filter' => new ContentTypeIdentifier('article'),
+                    'filter' => new ContentTypeIdentifier(['article']),
                     'sortClauses' => [
                         new DatePublished(Query::SORT_ASC),
                     ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
@@ -316,12 +316,6 @@ class AllTagFieldsTest extends QueryTypeBaseTest
             [
                 [
                     'content' => $content,
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
-                    'content' => $content,
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
@@ -312,13 +312,6 @@ class ForwardFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => 'field',
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
-                    'content' => $content,
-                    'relation_field' => 'field',
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
@@ -243,42 +243,42 @@ class ReverseFieldsTest extends QueryTypeBaseTest
             [
                 [
                     'content' => $content,
+                    'relation_field' => 'field',
                     'content_type' => 1,
                 ],
             ],
             [
                 [
                     'content' => $content,
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
-                    'content' => $content,
+                    'relation_field' => 'field',
                     'field' => 1,
                 ],
             ],
             [
                 [
                     'content' => $content,
+                    'relation_field' => 'field',
                     'publication_date' => true,
                 ],
             ],
             [
                 [
                     'content' => $content,
+                    'relation_field' => 'field',
                     'publication_date' => [false],
                 ],
             ],
             [
                 [
                     'content' => $content,
+                    'relation_field' => 'field',
                     'limit' => 'five',
                 ],
             ],
             [
                 [
                     'content' => $content,
+                    'relation_field' => 'field',
                     'offset' => 'ten',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
@@ -329,13 +329,6 @@ class TagFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => 'field',
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
-                    'content' => $content,
-                    'relation_field' => 'field',
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
@@ -262,12 +262,6 @@ class ChildrenTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
-                    'location' => $location,
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
@@ -229,11 +229,6 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Depth as DepthSortClause;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Priority;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SectionIdentifier;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\Fetch;
 use Netgen\EzPlatformSiteApi\Tests\Unit\Core\Site\QueryType\QueryTypeBaseTest;
 
@@ -109,7 +110,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'content_type' => 'article',
+                    'section' => 'standard',
                     'field' => [],
                     'depth' => 5,
                     'sort' => [
@@ -119,7 +120,7 @@ class FetchTest extends QueryTypeBaseTest
                 ],
                 new LocationQuery([
                     'filter' => new LogicalAnd([
-                        new ContentTypeIdentifier('article'),
+                        new SectionIdentifier('standard'),
                         new DepthCriterion(Operator::EQ, 5),
                     ]),
                     'sortClauses' => [
@@ -130,7 +131,9 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'content_type' => 'article',
+                    'section' => [
+                        'eq' => 'standard',
+                    ],
                     'field' => [
                         'title' => 'Hello',
                     ],
@@ -138,7 +141,7 @@ class FetchTest extends QueryTypeBaseTest
                 ],
                 new LocationQuery([
                     'filter' => new LogicalAnd([
-                        new ContentTypeIdentifier('article'),
+                        new SectionIdentifier('standard'),
                         new Field('title', Operator::EQ, 'Hello'),
                     ]),
                     'sortClauses' => [
@@ -148,7 +151,11 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'content_type' => 'article',
+                    'section' => [
+                        'in' => [
+                            'standard',
+                        ],
+                    ],
                     'parent_location_id' => 42,
                     'subtree' => '/1/2/42/',
                     'field' => [
@@ -163,7 +170,7 @@ class FetchTest extends QueryTypeBaseTest
                 ],
                 new LocationQuery([
                     'filter' => new LogicalAnd([
-                        new ContentTypeIdentifier('article'),
+                        new SectionIdentifier(['standard']),
                         new ParentLocationId(42),
                         new Subtree('/1/2/42/'),
                         new Field('title', Operator::EQ, 'Hello'),

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
@@ -314,12 +314,6 @@ class SiblingsTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
-                    'location' => $location,
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
@@ -325,12 +325,6 @@ class SubtreeTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'content_type' => [1],
-                ],
-            ],
-            [
-                [
-                    'location' => $location,
                     'field' => 1,
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/QueryTypeBaseTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/QueryTypeBaseTest.php
@@ -5,7 +5,7 @@ namespace Netgen\EzPlatformSiteApi\Tests\Unit\Core\Site\QueryType;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
  * Base QueryType test case.
@@ -118,7 +118,7 @@ abstract class QueryTypeBaseTest extends TestCase
      */
     public function testGetQueryWithInvalidOptions(array $parameters)
     {
-        $this->expectException(ExceptionInterface::class);
+        $this->expectException(InvalidOptionsException::class);
 
         $queryType = $this->getQueryTypeUnderTest();
 


### PR DESCRIPTION
Because of too strictly defined allowed value validation, it was not possible to use `content_type` and `section` QueryType options as was documented, in the explicit operator form:

```yaml
content_type:
    in:
        [article, blog_post]
section:
    eq: standard
```

This relaxes the validation and allows defining these options with explicit operators.