### PR TITLE
Allow defining publication_date with explicit operators

### DIFF
--- a/docs/reference/query_types/content_fetch.rst
+++ b/docs/reference/query_types/content_fetch.rst
@@ -9,7 +9,7 @@ This Query Type is used to build general purpose Location queries.
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
 | conditions  | - `is_field_empty`_                                                          |
-|             | - `publication_date`_                                                        |
+|             | - `creation_date`_                                                           |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/content_relations_all_tag_fields.rst
+++ b/docs/reference/query_types/content_relations_all_tag_fields.rst
@@ -22,7 +22,7 @@ of a given Content.
 | Common      | - `content_type`_                                                                  |
 | Content     | - `field`_                                                                         |
 | conditions  | - `is_field_empty`_                                                                |
-|             | - `publication_date`_                                                              |
+|             | - `creation_date`_                                                                 |
 |             | - `section`_                                                                       |
 |             | - `state`_                                                                         |
 +-------------+------------------------------------------------------------------------------------+

--- a/docs/reference/query_types/content_relations_forward_fields.rst
+++ b/docs/reference/query_types/content_relations_forward_fields.rst
@@ -12,7 +12,7 @@ This Query Type is used to build fetch Content that is related to from relation 
 | Common      | - `content_type`_                                                                            |
 | Content     | - `field`_                                                                                   |
 | conditions  | - `is_field_empty`_                                                                          |
-|             | - `publication_date`_                                                                        |
+|             | - `creation_date`_                                                                           |
 |             | - `section`_                                                                                 |
 |             | - `state`_                                                                                   |
 +-------------+----------------------------------------------------------------------------------------------+

--- a/docs/reference/query_types/content_relations_reverse_fields.rst
+++ b/docs/reference/query_types/content_relations_reverse_fields.rst
@@ -12,7 +12,7 @@ This Query Type is used to build fetch Content that relates to the given Content
 | Common      | - `content_type`_                                                                            |
 | Content     | - `field`_                                                                                   |
 | conditions  | - `is_field_empty`_                                                                          |
-|             | - `publication_date`_                                                                        |
+|             | - `creation_date`_                                                                           |
 |             | - `section`_                                                                                 |
 |             | - `state`_                                                                                   |
 +-------------+----------------------------------------------------------------------------------------------+

--- a/docs/reference/query_types/content_relations_tag_fields.rst
+++ b/docs/reference/query_types/content_relations_tag_fields.rst
@@ -23,7 +23,7 @@ fields of a given Content.
 | Common      | - `content_type`_                                                                        |
 | Content     | - `field`_                                                                               |
 | conditions  | - `is_field_empty`_                                                                      |
-|             | - `publication_date`_                                                                    |
+|             | - `creation_date`_                                                                       |
 |             | - `section`_                                                                             |
 |             | - `state`_                                                                               |
 +-------------+------------------------------------------------------------------------------------------+

--- a/docs/reference/query_types/location_children.rst
+++ b/docs/reference/query_types/location_children.rst
@@ -16,7 +16,7 @@ This Query Type is used to build queries that fetch children Locations.
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
 | conditions  | - `is_field_empty`_                                                          |
-|             | - `publication_date`_                                                        |
+|             | - `creation_date`_                                                           |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/location_fetch.rst
+++ b/docs/reference/query_types/location_fetch.rst
@@ -16,7 +16,7 @@ This Query Type is used to build general purpose Location queries.
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
 | conditions  | - `is_field_empty`_                                                          |
-|             | - `publication_date`_                                                        |
+|             | - `creation_date`_                                                           |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/location_siblings.rst
+++ b/docs/reference/query_types/location_siblings.rst
@@ -16,7 +16,7 @@ This Query Type is used to build queries that fetch Location siblings.
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
 | conditions  | - `is_field_empty`_                                                          |
-|             | - `publication_date`_                                                        |
+|             | - `creation_date`_                                                           |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/location_subtree.rst
+++ b/docs/reference/query_types/location_subtree.rst
@@ -18,7 +18,7 @@ This Query Type is used to build queries that fetch from the Location subtree.
 | Common      | - `content_type`_                                                            |
 | Content     | - `field`_                                                                   |
 | conditions  | - `is_field_empty`_                                                          |
-|             | - `publication_date`_                                                        |
+|             | - `creation_date`_                                                           |
 |             | - `section`_                                                                 |
 |             | - `state`_                                                                   |
 +-------------+------------------------------------------------------------------------------+

--- a/docs/reference/query_types/parameters/common/content/creation_date.rst.inc
+++ b/docs/reference/query_types/parameters/common/content/creation_date.rst.inc
@@ -1,7 +1,8 @@
-``publication_date``
-~~~~~~~~~~~~~~~~~~~~
+``creation_date``
+~~~~~~~~~~~~~~~~~
 
-Defines the publication date of the Content as a timestamp.
+Defines the creation (publication) date of the Content as a timestamp or time string as accepted by
+PHP function `strtotime <https://www.php.net/manual/en/function.strtotime.php>`_.
 
 - **value type**: ``integer``
 - **value format**: ``single``, ``array``
@@ -15,7 +16,7 @@ Examples:
 .. code-block:: yaml
 
     # identical to the example below
-    publication_date: 1535117737
+    creation_date: 1535117737
 
 .. code-block:: yaml
 
@@ -25,26 +26,26 @@ Examples:
 .. code-block:: yaml
 
     # identical to the example below
-    publication_date: [1435117737, 1535117737]
+    creation_date: [1435117737, 1535117737]
 
 .. code-block:: yaml
 
-    publication_date:
+    creation_date:
         in: [1435117737, 1535117737]
 
 .. code-block:: yaml
 
     # multiple operators are combined with logical AND
-    publication_date:
+    creation_date:
         gt: '29 June 1991'
         lte: '5 August 1995'
 
 .. code-block:: yaml
 
-    publication_date:
+    creation_date:
         gt: 'today'
 
 .. code-block:: yaml
 
-    publication_date:
+    creation_date:
         between: ['today', '+1 week 2 days 4 hours 2 seconds']

--- a/docs/reference/query_types/parameters/common_content_parameters.rst.inc
+++ b/docs/reference/query_types/parameters/common_content_parameters.rst.inc
@@ -4,6 +4,6 @@ Common Content conditions
 .. include:: /reference/query_types/parameters/common/content/content_type.rst.inc
 .. include:: /reference/query_types/parameters/common/content/field.rst.inc
 .. include:: /reference/query_types/parameters/common/content/is_field_empty.rst.inc
-.. include:: /reference/query_types/parameters/common/content/publication_date.rst.inc
+.. include:: /reference/query_types/parameters/common/content/creation_date.rst.inc
 .. include:: /reference/query_types/parameters/common/content/section.rst.inc
 .. include:: /reference/query_types/parameters/common/content/state.rst.inc

--- a/lib/Core/Site/QueryType/Base.php
+++ b/lib/Core/Site/QueryType/Base.php
@@ -243,22 +243,6 @@ abstract class Base implements QueryType
         $resolver->setAllowedTypes('state', ['array']);
 
         $resolver->setAllowedValues(
-            'publication_date',
-            function ($dates) {
-                if (!is_array($dates)) {
-                    return true;
-                }
-
-                foreach ($dates as $date) {
-                    if (!is_int($date) && !is_string($date)) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-        );
-        $resolver->setAllowedValues(
             'is_field_empty',
             static function ($isEmptyMap) {
                 foreach ($isEmptyMap as $key => $value) {

--- a/lib/Core/Site/QueryType/Base.php
+++ b/lib/Core/Site/QueryType/Base.php
@@ -224,6 +224,7 @@ abstract class Base implements QueryType
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
         ]);
@@ -240,6 +241,7 @@ abstract class Base implements QueryType
         $resolver->setAllowedTypes('limit', ['int']);
         $resolver->setAllowedTypes('offset', ['int']);
         $resolver->setAllowedTypes('publication_date', ['int', 'string', 'array']);
+        $resolver->setAllowedTypes('creation_date', ['int', 'string', 'array']);
         $resolver->setAllowedTypes('state', ['array']);
 
         $resolver->setAllowedValues(
@@ -281,6 +283,7 @@ abstract class Base implements QueryType
                 case 'parent_location_id':
                 case 'priority':
                 case 'publication_date':
+                case 'creation_date':
                 case 'section':
                 case 'subtree':
                 case 'visible':

--- a/lib/Core/Site/QueryType/CriteriaBuilder.php
+++ b/lib/Core/Site/QueryType/CriteriaBuilder.php
@@ -79,6 +79,7 @@ final class CriteriaBuilder
             case 'priority':
                 return $this->buildPriority($definition);
             case 'publication_date':
+            case 'creation_date':
                 return $this->buildDateMetadataCreated($definition);
             case 'section':
                 return $this->buildSection($definition);

--- a/lib/Core/Site/QueryType/CriteriaBuilder.php
+++ b/lib/Core/Site/QueryType/CriteriaBuilder.php
@@ -78,7 +78,12 @@ final class CriteriaBuilder
                 return $this->buildParentLocationId($definition);
             case 'priority':
                 return $this->buildPriority($definition);
+            /** @noinspection PhpMissingBreakStatementInspection */
             case 'publication_date':
+                @trigger_error(
+                    'publication_date is deprecated for removal in 3.0. Use creation_date instead.',
+                    E_USER_DEPRECATED
+                );
             case 'creation_date':
                 return $this->buildDateMetadataCreated($definition);
             case 'section':

--- a/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
@@ -38,6 +38,7 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -164,7 +165,7 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                     'sort' => [
                         new DatePublished(Query::SORT_DESC),
                         new ContentName(Query::SORT_ASC),
@@ -218,7 +219,7 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -251,7 +252,7 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
         return [
             [
                 [
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
@@ -223,11 +223,6 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Base/CustomQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/CustomQueryTypeTest.php
@@ -41,6 +41,7 @@ class CustomQueryTypeTest extends TestCase
                 'field',
                 'is_field_empty',
                 'publication_date',
+                'creation_date',
                 'section',
                 'state',
                 'sort',

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -273,6 +273,24 @@ class FetchTest extends QueryTypeBaseTest
                     ],
                 ]),
             ],
+            [
+                [
+                    'publication_date' => [
+                        'gte' => '4 May 2018',
+                    ],
+                    'sort' => 'published asc',
+                ],
+                new Query([
+                    'filter' => new DateMetadata(
+                        DateMetadata::CREATED,
+                        Operator::GTE,
+                        1525384800
+                    ),
+                    'sortClauses' => [
+                        new DatePublished(Query::SORT_ASC),
+                    ],
+                ]),
+            ],
         ];
     }
 

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -188,6 +188,90 @@ class FetchTest extends QueryTypeBaseTest
                     ],
                 ]),
             ],
+            [
+                [
+                    'publication_date' => [
+                        'eq' => '4 May 2018',
+                    ],
+                    'sort' => 'published asc',
+                ],
+                new Query([
+                    'filter' => new DateMetadata(
+                        DateMetadata::CREATED,
+                        Operator::EQ,
+                        1525384800
+                    ),
+                    'sortClauses' => [
+                        new DatePublished(Query::SORT_ASC),
+                    ],
+                ]),
+            ],
+            [
+                [
+                    'publication_date' => [
+                        'in' => [
+                            '4 May 2018',
+                            '21 July 2019',
+                        ],
+                    ],
+                    'sort' => 'published asc',
+                ],
+                new Query([
+                    'filter' => new DateMetadata(
+                        DateMetadata::CREATED,
+                        Operator::IN,
+                        [
+                            1525384800,
+                            1563660000,
+                        ]
+                    ),
+                    'sortClauses' => [
+                        new DatePublished(Query::SORT_ASC),
+                    ],
+                ]),
+            ],
+            [
+                [
+                    'publication_date' => [
+                        'between' => [
+                            '4 May 2018',
+                            '21 July 2019',
+                        ],
+                    ],
+                    'sort' => 'published asc',
+                ],
+                new Query([
+                    'filter' => new DateMetadata(
+                        DateMetadata::CREATED,
+                        Operator::BETWEEN,
+                        [
+                            1525384800,
+                            1563660000,
+                        ]
+                    ),
+                    'sortClauses' => [
+                        new DatePublished(Query::SORT_ASC),
+                    ],
+                ]),
+            ],
+            [
+                [
+                    'publication_date' => [
+                        'gte' => '4 May 2018',
+                    ],
+                    'sort' => 'published asc',
+                ],
+                new Query([
+                    'filter' => new DateMetadata(
+                        DateMetadata::CREATED,
+                        Operator::GTE,
+                        1525384800
+                    ),
+                    'sortClauses' => [
+                        new DatePublished(Query::SORT_ASC),
+                    ],
+                ]),
+            ],
         ];
     }
 

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -295,11 +295,6 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -38,6 +38,7 @@ class FetchTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -170,7 +171,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                     'sort' => [
                         new DatePublished(Query::SORT_DESC),
                         new ContentName(Query::SORT_ASC),
@@ -190,7 +191,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => [
+                    'creation_date' => [
                         'eq' => '4 May 2018',
                     ],
                     'sort' => 'published asc',
@@ -208,7 +209,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => [
+                    'creation_date' => [
                         'in' => [
                             '4 May 2018',
                             '21 July 2019',
@@ -232,7 +233,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => [
+                    'creation_date' => [
                         'between' => [
                             '4 May 2018',
                             '21 July 2019',
@@ -256,7 +257,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => [
+                    'creation_date' => [
                         'gte' => '4 May 2018',
                     ],
                     'sort' => 'published asc',
@@ -290,7 +291,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -311,7 +312,7 @@ class FetchTest extends QueryTypeBaseTest
         return [
             [
                 [
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
@@ -328,12 +328,6 @@ class AllTagFieldsTest extends QueryTypeBaseTest
             [
                 [
                     'content' => $content,
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
-                    'content' => $content,
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/AllTagFieldsTest.php
@@ -125,6 +125,7 @@ class AllTagFieldsTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -277,7 +278,7 @@ class AllTagFieldsTest extends QueryTypeBaseTest
             [
                 [
                     'content' => $contentWithTags,
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                     'sort' => [
                         new DatePublished(Query::SORT_DESC),
                         new ContentName(Query::SORT_ASC),
@@ -322,7 +323,7 @@ class AllTagFieldsTest extends QueryTypeBaseTest
             [
                 [
                     'content' => $content,
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -348,7 +349,7 @@ class AllTagFieldsTest extends QueryTypeBaseTest
             [
                 [
                     'content' => $content,
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
@@ -109,6 +109,7 @@ class ForwardFieldsTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -242,7 +243,7 @@ class ForwardFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => ['relations_a', 'relations_b'],
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                     'sort' => [
                         new DatePublished(Query::SORT_DESC),
                         new ContentName(Query::SORT_ASC),
@@ -319,7 +320,7 @@ class ForwardFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => 'field',
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -354,7 +355,7 @@ class ForwardFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => ['relations_a', 'relations_b'],
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ForwardFieldsTest.php
@@ -326,13 +326,6 @@ class ForwardFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => 'field',
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
-                    'content' => $content,
-                    'relation_field' => 'field',
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
@@ -73,6 +73,7 @@ class ReverseFieldsTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -210,7 +211,7 @@ class ReverseFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => ['relations_a', 'relations_b'],
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                     'sort' => [
                         new DatePublished(Query::SORT_DESC),
                         new ContentName(Query::SORT_ASC),
@@ -258,7 +259,7 @@ class ReverseFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => 'field',
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -293,7 +294,7 @@ class ReverseFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => ['relations_a', 'relations_b'],
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/ReverseFieldsTest.php
@@ -265,13 +265,6 @@ class ReverseFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => 'field',
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
-                    'content' => $content,
-                    'relation_field' => 'field',
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
@@ -343,13 +343,6 @@ class TagFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => 'field',
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
-                    'content' => $content,
-                    'relation_field' => 'field',
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/Relations/TagFieldsTest.php
@@ -117,6 +117,7 @@ class TagFieldsTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -258,7 +259,7 @@ class TagFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => ['tags_a', 'tags_b'],
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                     'sort' => [
                         new DatePublished(Query::SORT_DESC),
                         new ContentName(Query::SORT_ASC),
@@ -336,7 +337,7 @@ class TagFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => 'field',
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -371,7 +372,7 @@ class TagFieldsTest extends QueryTypeBaseTest
                 [
                     'content' => $content,
                     'relation_field' => ['tags_a', 'tags_b'],
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/CriteriaBuilderTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/CriteriaBuilderTest.php
@@ -213,7 +213,7 @@ class CriteriaBuilderTest extends TestCase
             [
                 [
                     new CriterionDefinition([
-                        'name' => 'publication_date',
+                        'name' => 'creation_date',
                         'target' => null,
                         'operator' => Operator::BETWEEN,
                         'value' => [123, 456],
@@ -422,7 +422,7 @@ class CriteriaBuilderTest extends TestCase
 
         $criteriaBuilder->build([
             new CriterionDefinition([
-                'name' => 'publication_date',
+                'name' => 'creation_date',
                 'target' => null,
                 'operator' => null,
                 'value' => 'someday',

--- a/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
@@ -57,6 +57,7 @@ class ChildrenTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -229,7 +230,7 @@ class ChildrenTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                 ],
                 new LocationQuery([
                     'filter' => new LogicalAnd([
@@ -268,7 +269,7 @@ class ChildrenTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -294,7 +295,7 @@ class ChildrenTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
@@ -274,12 +274,6 @@ class ChildrenTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
-                    'location' => $location,
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
@@ -246,11 +246,6 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/FetchTest.php
@@ -45,6 +45,7 @@ class FetchTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -213,7 +214,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                 ],
                 new LocationQuery([
                     'filter' => new DateMetadata(
@@ -241,7 +242,7 @@ class FetchTest extends QueryTypeBaseTest
             ],
             [
                 [
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -262,7 +263,7 @@ class FetchTest extends QueryTypeBaseTest
         return [
             [
                 [
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
@@ -326,12 +326,6 @@ class SiblingsTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
-                    'location' => $location,
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
@@ -88,6 +88,7 @@ class SiblingsTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -280,7 +281,7 @@ class SiblingsTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                 ],
                 new LocationQuery([
                     'filter' => new LogicalAnd([
@@ -320,7 +321,7 @@ class SiblingsTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -346,7 +347,7 @@ class SiblingsTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
@@ -337,12 +337,6 @@ class SubtreeTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => [false],
-                ],
-            ],
-            [
-                [
-                    'location' => $location,
                     'limit' => 'five',
                 ],
             ],

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
@@ -61,6 +61,7 @@ class SubtreeTest extends QueryTypeBaseTest
             'field',
             'is_field_empty',
             'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',
@@ -294,7 +295,7 @@ class SubtreeTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => '4 May 2018',
+                    'creation_date' => '4 May 2018',
                 ],
                 new LocationQuery([
                     'filter' => new LogicalAnd([
@@ -331,7 +332,7 @@ class SubtreeTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => true,
+                    'creation_date' => true,
                 ],
             ],
             [
@@ -357,7 +358,7 @@ class SubtreeTest extends QueryTypeBaseTest
             [
                 [
                     'location' => $location,
-                    'publication_date' => [
+                    'creation_date' => [
                         'like' => 5,
                     ],
                 ],

--- a/tests/lib/Unit/Core/Site/QueryType/QueryTypeBaseTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/QueryTypeBaseTest.php
@@ -72,7 +72,7 @@ abstract class QueryTypeBaseTest extends TestCase
             'content_type',
             'field',
             'is_field_empty',
-            'publication_date',
+            'creation_date',
             'section',
             'state',
             'sort',


### PR DESCRIPTION
Because of too strictly defined allowed value validation, it was not possible to use `publication_date` option with some explicit operators, for example:

```yaml
publication_date:
    between: [yesterday, today]
```

This relaxes the validation and enables defining all operators as documented.

Additionally, `creation_date` is added as an alias to `publication_date`, which is deprecated for removal in 3.0. Reason for deprecation is because the old name can be misleading, as Content can be published multiple times, and `publication_date` really refers to the date of the first publishing. Also, in future we will add support for `modification_date`, which also makes new name more sensible.