### PR TITLE
Allow null value for is_field_empty option

### DIFF
--- a/docs/reference/query_types/parameters/common/content/is_field_empty.rst.inc
+++ b/docs/reference/query_types/parameters/common/content/is_field_empty.rst.inc
@@ -5,11 +5,11 @@ Defines conditions on whether the Content fields are empty or not.
 
 .. note::
 
-  ``IsEmptyField`` criterion is upported only by Solr search engine, so this condition can be
+  ``IsEmptyField`` criterion is supported only by Solr search engine, so this condition can be
   used only with the ``FindService``. In order to use it configure the query with parameter ``use_filter``
   set to ``false``.
 
-- **value type**: ``boolean``
+- **value type**: ``boolean``, ``null``
 - **value format**: ``single``
 - **operators**: ``eq``
 - **target**: ``string`` Field identifier
@@ -23,3 +23,9 @@ Examples:
     is_field_empty:
         image: false
         video: true
+
+.. code-block:: yaml
+
+    # allow both empty and non-empty fields, which is also the default behaviour
+    is_field_empty:
+        audio: ~

--- a/lib/Core/Site/QueryType/Base.php
+++ b/lib/Core/Site/QueryType/Base.php
@@ -248,7 +248,7 @@ abstract class Base implements QueryType
             'is_field_empty',
             static function ($isEmptyMap) {
                 foreach ($isEmptyMap as $key => $value) {
-                    if (!is_string($key) || !is_bool($value)) {
+                    if (!is_string($key) || ($value !== null && !is_bool($value))) {
                         return false;
                     }
                 }

--- a/lib/Core/Site/QueryType/CriteriaBuilder.php
+++ b/lib/Core/Site/QueryType/CriteriaBuilder.php
@@ -330,6 +330,10 @@ final class CriteriaBuilder
      */
     private function buildIsFieldEmpty(CriterionDefinition $definition)
     {
+        if ($definition->value === null) {
+            return null;
+        }
+
         $value = $definition->value ? IsFieldEmpty::IS_EMPTY : IsFieldEmpty::IS_NOT_EMPTY;
 
         return new IsFieldEmpty($definition->target, $value);

--- a/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Base/BaseQueryTypeTest.php
@@ -188,6 +188,7 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
                     'is_field_empty' => [
                         'image' => false,
                         'video' => true,
+                        'audio' => null,
                     ],
                     'sort' => 'published desc',
                 ],
@@ -196,6 +197,20 @@ class BaseQueryTypeTest extends QueryTypeBaseTest
                         new IsFieldEmpty('image', IsFieldEmpty::IS_NOT_EMPTY),
                         new IsFieldEmpty('video', IsFieldEmpty::IS_EMPTY),
                     ]),
+                    'sortClauses' => [
+                        new DatePublished(Query::SORT_DESC),
+                    ],
+                ]),
+            ],
+            [
+                [
+                    'is_field_empty' => [
+                        'image' => null,
+                    ],
+                    'sort' => 'published desc',
+                ],
+                new Query([
+                    'filter' => null,
                     'sortClauses' => [
                         new DatePublished(Query::SORT_DESC),
                     ],

--- a/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Content/FetchTest.php
@@ -322,6 +322,13 @@ class FetchTest extends QueryTypeBaseTest
                     'offset' => 'ten',
                 ],
             ],
+            [
+                [
+                    'is_field_empty' => [
+                        'audio' => 7,
+                    ],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This enables using `null` as a value for `is_field_empty` option, same as is already possible with other boolean options `visibility` and `main`:

```yaml
is_field_empty:
    image: true
    video: false
    audio: ~
```