### PR TITLE
Add parameters provided to extension to the view builder

### DIFF
--- a/bundle/Templating/Twig/Extension/ContentViewRuntime.php
+++ b/bundle/Templating/Twig/Extension/ContentViewRuntime.php
@@ -98,7 +98,7 @@ class ContentViewRuntime
             'content' => $content,
             'location' => $this->getLocation($contentOrLocation),
             '_controller' => 'ng_content:viewAction',
-        ]);
+        ] + $parameters);
 
         if (!$this->viewMatched($view)) {
             throw new LogicException("Couldn't match view '{$viewType}' for Content #{$content->id}");


### PR DESCRIPTION
Many event subscribers that use `ViewEvents::FILTER_VIEW_PARAMETERS` event from eZ kernel depend on parameters provided by the render controller call.

e.g. this call:

```
{{ render(
    controller(
        'ng_content:viewAction', {
            'content': content,
            'location': object,
            'viewType': 'line',
            'layout': false,
            'params': {
                'foo': 'bar',
                'other': 'baz',
            }
        }
    )
) }}
```

when rewritten to `ng_view_content` call:

```
{{ ng_view_content(
    location,
    'line', {
        'layout': false,
        'params': {
            'foo': 'bar',
            'other': 'baz',
        }
    }
) }}
```

Didn't take into account the `layout` param, nor transfer `params` hash into the view (both being handled by `ViewEvents::FILTER_VIEW_PARAMETERS` subscribers).