### PR TITLE
Use layout as separate parameter for ng_view_content

### DIFF
--- a/bundle/Templating/Twig/Extension/ContentViewRuntime.php
+++ b/bundle/Templating/Twig/Extension/ContentViewRuntime.php
@@ -79,6 +79,7 @@ class ContentViewRuntime
      * @param \eZ\Publish\API\Repository\Values\ValueObject $contentOrLocation
      * @param string $viewType
      * @param array $parameters
+     * @param bool $layout
      *
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
@@ -89,22 +90,22 @@ class ContentViewRuntime
     public function renderContentView(
         ValueObject $contentOrLocation,
         string $viewType,
-        array $parameters = []
+        array $parameters = [],
+        bool $layout = false
     ): string {
         $content = $this->getContent($contentOrLocation);
 
         $view = $this->viewBuilder->buildView([
-            'viewType' => $viewType,
             'content' => $content,
             'location' => $this->getLocation($contentOrLocation),
+            'viewType' => $viewType,
+            'layout' => $layout,
             '_controller' => 'ng_content:viewAction',
         ] + $parameters);
 
         if (!$this->viewMatched($view)) {
             throw new LogicException("Couldn't match view '{$viewType}' for Content #{$content->id}");
         }
-
-        $view->addParameters($parameters);
 
         $controllerReference = $view->getControllerReference();
 
@@ -196,6 +197,7 @@ class ContentViewRuntime
 
         $request = $request->duplicate();
         $request->attributes->set('view', $contentView);
+        $request->attributes->add($contentView->getParameters());
 
         return $this->argumentResolver->getArguments($request, $controller);
     }

--- a/bundle/Templating/Twig/Extension/ContentViewRuntime.php
+++ b/bundle/Templating/Twig/Extension/ContentViewRuntime.php
@@ -113,7 +113,7 @@ class ContentViewRuntime
             return $this->viewRenderer->render($view);
         }
 
-        return $this->renderController($view, $controllerReference);
+        return $this->renderController($view, $controllerReference, ['layout' => $layout] + $parameters);
     }
 
     /**
@@ -154,10 +154,10 @@ class ContentViewRuntime
         throw new LogicException('Given value must be Content or Location instance.');
     }
 
-    private function renderController(ContentView $contentView, ControllerReference $controllerReference): string
+    private function renderController(ContentView $contentView, ControllerReference $controllerReference, array $arguments): string
     {
         $controller = $this->resolveController($controllerReference);
-        $arguments = $this->resolveControllerArguments($contentView, $controller);
+        $arguments = $this->resolveControllerArguments($contentView, $controller, $arguments);
 
         $result = call_user_func_array($controller, $arguments);
 
@@ -187,7 +187,7 @@ class ContentViewRuntime
         return $controller;
     }
 
-    private function resolveControllerArguments(ContentView $contentView, callable $controller): array
+    private function resolveControllerArguments(ContentView $contentView, callable $controller, array $arguments): array
     {
         $request = $this->requestStack->getMasterRequest();
 
@@ -198,6 +198,7 @@ class ContentViewRuntime
         $request = $request->duplicate();
         $request->attributes->set('view', $contentView);
         $request->attributes->add($contentView->getParameters());
+        $request->attributes->add($arguments);
 
         return $this->argumentResolver->getArguments($request, $controller);
     }


### PR DESCRIPTION
This defines `layout` as a separate parameter for `ng_view_content`. It's the last parameter and defaults to `false`, since that will fit most use cases. Full example:

```twig
{{ ng_view_content(
    content,
    'line',
    {
        'foo': 'bar',
        'params': {'custom': 'value'}
    },
    false 
) }}
```

Third parameter now represents custom view parameters directly.

Additionally this fixes the problem where arbitrary view params were not injected to the controller arguments (`foo` in the example above) but it was injected in the template.