### PR TITLE
Add support for eZ Platform v3 version of RepositoryFactory::buildRepository

### DIFF
--- a/lib/Resources/config/internal.yml
+++ b/lib/Resources/config/internal.yml
@@ -25,6 +25,7 @@ services:
             - '@ezpublish.spi.search.legacy'
             - '@?ezpublish.search.background_indexer'
             - '@?ezpublish.repository.relation_processor'
+            - '@?eZ\Publish\Core\FieldType\FieldTypeRegistry'
         lazy: true
         public: false
         tags:


### PR DESCRIPTION
https://github.com/ezsystems/ezpublish-kernel/pull/2688 updated the signature of `buildRepository` method to add a new argument.

The service is added with `@?` annotation in order not to crash on eZ Platform 2.5 where the service does not exist.