### PR TITLE
Add configuration for surrogate field rendering

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -46,5 +46,9 @@ class Configuration extends SiteAccessConfiguration
             ->booleanNode('fail_on_missing_fields')
                 ->info('Whether to fail on missing Content Fields')
             ->end();
+        $systemNode
+            ->booleanNode('render_missing_field_info')
+                ->info('Whether to render useful debug information in place of a missing field')
+            ->end();
     }
 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -11,7 +11,7 @@ parameters:
     netgen_ez_platform_site_api.default.override_url_alias_view_action: false
     netgen_ez_platform_site_api.default.use_always_available_fallback: true
     netgen_ez_platform_site_api.default.fail_on_missing_fields: '%kernel.debug%'
-    netgen_ez_platform_site_api.default.render_missing_field_info: true
+    netgen_ez_platform_site_api.default.render_missing_field_info: false
 
 services:
     netgen.ezplatform_site.controller.base:

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -11,6 +11,7 @@ parameters:
     netgen_ez_platform_site_api.default.override_url_alias_view_action: false
     netgen_ez_platform_site_api.default.use_always_available_fallback: true
     netgen_ez_platform_site_api.default.fail_on_missing_fields: '%kernel.debug%'
+    netgen_ez_platform_site_api.default.render_missing_field_info: true
 
 services:
     netgen.ezplatform_site.controller.base:

--- a/bundle/Resources/views/content_fields.html.twig
+++ b/bundle/Resources/views/content_fields.html.twig
@@ -1,1 +1,5 @@
-{% block ngsurrogate_field %}{% endblock %}
+{% block ngsurrogate_field %}{% apply spaceless %}
+    {% if ezpublish.configResolver.getParameter('render_missing_field_info', 'netgen_ez_platform_site_api') == true %}
+        <span title="Missing field '{{ contentTypeIdentifier }}/{{ field.fieldDefIdentifier }}', Content ID:{{ content.id }}" style="font-size:48px">🐞</span>
+    {% endif %}
+{% endapply %}{% endblock %}


### PR DESCRIPTION
This adds siteaccess aware configuration option `render_missing_field_info`, which controls whether surrogate field will be rendered as an empty string or it will render useful debug information.