### PR TITLE
Remove content_view provider for Site API ContentView

### DIFF
--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -30,24 +30,6 @@ services:
             - [setMatchConfig, [$ngcontent_view$]]
         public: false
 
-    netgen.ezplatform_site.content_view_provider.configured:
-        class: eZ\Bundle\EzPublishCoreBundle\View\Provider\Configured
-        arguments:
-            - '@netgen.ezplatform_site.content_view.matcher_factory'
-        tags:
-            - { name: ezpublish.view_provider, type: 'Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView', priority: 100 }
-        public: false
-
-    netgen.ezplatform_site.content_view.matcher_factory:
-        class: eZ\Bundle\EzPublishCoreBundle\Matcher\ServiceAwareMatcherFactory
-        arguments:
-            - '@ezpublish.api.repository'
-            - 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased'
-        calls:
-            - [setContainer, ["@service_container"]]
-            - [setMatchConfig, [$content_view$]]
-        public: false
-
     netgen.ezplatform_site.ngcontent_view_provider.default_configured:
         class: eZ\Bundle\EzPublishCoreBundle\View\Provider\Configured
         arguments:


### PR DESCRIPTION
`content_view` Content view provider for Site API ContentView was introduced with `ngcontent_view` in https://github.com/netgen/ezplatform-site-api/pull/23, in order to keep backward compatibility with Site API v1. Now, with v3 soon to be released, we can get rid of it.