### PR TITLE
Default view templates

### DIFF
--- a/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
@@ -53,6 +53,7 @@ class NetgenEzPlatformSiteApiExtension extends Extension implements PrependExten
 
         $fileLocator = new FileLocator(__DIR__ . '/../Resources/config');
         $loader = new Loader\YamlFileLoader($container, $fileLocator);
+        $loader->load('default_settings.yml');
         $loader->load('services.yml');
         $loader->load('view.yml');
 

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -6,13 +6,13 @@ parameters:
     netgen_ez_platform_site_api.default.render_missing_field_info: false
 
     # Default view templates
-    netgen.ezplatform_site.default_view_templates.content.asset_image: 'NetgenEzPlatformSiteApiBundle:default:content/asset_image.html.twig'
-    netgen.ezplatform_site.default_view_templates.content.embed: 'NetgenEzPlatformSiteApiBundle:default:content/embed.html.twig'
-    netgen.ezplatform_site.default_view_templates.content.embed_image: 'NetgenEzPlatformSiteApiBundle:default:content/embed_image.html.twig'
-    netgen.ezplatform_site.default_view_templates.content.embed_inline: 'NetgenEzPlatformSiteApiBundle:default:content/embed_inline.html.twig'
-    netgen.ezplatform_site.default_view_templates.content.full: 'NetgenEzPlatformSiteApiBundle:default:content/full.html.twig'
-    netgen.ezplatform_site.default_view_templates.content.line: 'NetgenEzPlatformSiteApiBundle:default:content/line.html.twig'
-    netgen.ezplatform_site.default_view_templates.content.text_linked: 'NetgenEzPlatformSiteApiBundle:default:content/text_linked.html.twig'
+    netgen.ezplatform_site.default_view_templates.content.asset_image: "@@NetgenEzPlatformSiteApi/default/content/asset_image.html.twig"
+    netgen.ezplatform_site.default_view_templates.content.embed: "@@NetgenEzPlatformSiteApi/default/content/embed.html.twig"
+    netgen.ezplatform_site.default_view_templates.content.embed_image: "@@NetgenEzPlatformSiteApi/default/content/embed_image.html.twig"
+    netgen.ezplatform_site.default_view_templates.content.embed_inline: "@@NetgenEzPlatformSiteApi/default/content/embed_inline.html.twig"
+    netgen.ezplatform_site.default_view_templates.content.full: "@@NetgenEzPlatformSiteApi/default/content/full.html.twig"
+    netgen.ezplatform_site.default_view_templates.content.line: "@@NetgenEzPlatformSiteApi/default/content/line.html.twig"
+    netgen.ezplatform_site.default_view_templates.content.text_linked: "@@NetgenEzPlatformSiteApi/default/content/text_linked.html.twig"
     # List of content type identifiers to display as image when embedded
     netgen.ezplatform_site.content_view.image_embed_content_type_identifiers: ['image']
 
@@ -20,7 +20,7 @@ parameters:
     ezsettings.default.ng_named_query: {}
     ezsettings.default.ngcontent_view: {}
     # By default we don't override URL alias view action, for that reason this is commented out
-    #ezsettings.default.pagelayout: 'NetgenEzPlatformSiteApiBundle::pagelayout.html.twig'
+    #ezsettings.default.pagelayout: '@@NetgenEzPlatformSiteApi/pagelayout.html.twig'
 
     ezsettings.default.ngcontent_view_defaults:
         asset_image:

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -22,7 +22,7 @@ parameters:
     # By default we don't override URL alias view action, for that reason this is commented out
     #ezsettings.default.pagelayout: 'NetgenEzPlatformSiteApiBundle::pagelayout.html.twig'
 
-    ezsettings.default.ng_content_view_defaults:
+    ezsettings.default.ngcontent_view_defaults:
         asset_image:
             default:
                 template: '%netgen.ezplatform_site.default_view_templates.content.asset_image%'

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -1,0 +1,52 @@
+parameters:
+    # Defaults for Site API bundle semantic configuration
+    netgen_ez_platform_site_api.default.override_url_alias_view_action: false
+    netgen_ez_platform_site_api.default.use_always_available_fallback: true
+    netgen_ez_platform_site_api.default.fail_on_missing_fields: '%kernel.debug%'
+    netgen_ez_platform_site_api.default.render_missing_field_info: false
+
+    # Default view templates
+    netgen.ezplatform_site.default_view_templates.content.asset_image: 'NetgenEzPlatformSiteApiBundle:default:content/asset_image.html.twig'
+    netgen.ezplatform_site.default_view_templates.content.embed: 'NetgenEzPlatformSiteApiBundle:default:content/embed.html.twig'
+    netgen.ezplatform_site.default_view_templates.content.embed_image: 'NetgenEzPlatformSiteApiBundle:default:content/embed_image.html.twig'
+    netgen.ezplatform_site.default_view_templates.content.embed_inline: 'NetgenEzPlatformSiteApiBundle:default:content/embed_inline.html.twig'
+    netgen.ezplatform_site.default_view_templates.content.full: 'NetgenEzPlatformSiteApiBundle:default:content/full.html.twig'
+    netgen.ezplatform_site.default_view_templates.content.line: 'NetgenEzPlatformSiteApiBundle:default:content/line.html.twig'
+    netgen.ezplatform_site.default_view_templates.content.text_linked: 'NetgenEzPlatformSiteApiBundle:default:content/text_linked.html.twig'
+    netgen.ezplatform_site.content_view.image_embed_content_types_identifiers: ['image']
+
+    # Default eZ Platform settings
+    ezsettings.default.ng_named_query: {}
+    ezsettings.default.ngcontent_view: {}
+    # By default we don't override URL alias view action, for that reason this is commented out
+    #ezsettings.default.pagelayout: 'NetgenEzPlatformSiteApiBundle::pagelayout.html.twig'
+
+    ezsettings.default.ng_content_view_defaults:
+        asset_image:
+            default:
+                template: '%netgen.ezplatform_site.default_view_templates.content.asset_image%'
+                match: []
+        embed:
+            image:
+                template: '%netgen.ezplatform_site.default_view_templates.content.embed_image%'
+                match:
+                    Identifier\ContentType: '%netgen.ezplatform_site.content_view.image_embed_content_types_identifiers%'
+            default:
+                template: "%netgen.ezplatform_site.default_view_templates.content.embed%"
+                match: []
+        embed-inline:
+            default:
+                template: "%netgen.ezplatform_site.default_view_templates.content.embed_inline%"
+                match: []
+        full:
+            default:
+                template: "%netgen.ezplatform_site.default_view_templates.content.full%"
+                match: []
+        line:
+            default:
+                template: "%netgen.ezplatform_site.default_view_templates.content.line%"
+                match: []
+        text_linked:
+            default:
+                template: "%netgen.ezplatform_site.default_view_templates.content.text_linked%"
+                match: []

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -13,7 +13,8 @@ parameters:
     netgen.ezplatform_site.default_view_templates.content.full: 'NetgenEzPlatformSiteApiBundle:default:content/full.html.twig'
     netgen.ezplatform_site.default_view_templates.content.line: 'NetgenEzPlatformSiteApiBundle:default:content/line.html.twig'
     netgen.ezplatform_site.default_view_templates.content.text_linked: 'NetgenEzPlatformSiteApiBundle:default:content/text_linked.html.twig'
-    netgen.ezplatform_site.content_view.image_embed_content_types_identifiers: ['image']
+    # List of content type identifiers to display as image when embedded
+    netgen.ezplatform_site.content_view.image_embed_content_type_identifiers: ['image']
 
     # Default eZ Platform settings
     ezsettings.default.ng_named_query: {}
@@ -30,7 +31,7 @@ parameters:
             image:
                 template: '%netgen.ezplatform_site.default_view_templates.content.embed_image%'
                 match:
-                    Identifier\ContentType: '%netgen.ezplatform_site.content_view.image_embed_content_types_identifiers%'
+                    Identifier\ContentType: '%netgen.ezplatform_site.content_view.image_embed_content_type_identifiers%'
             default:
                 template: "%netgen.ezplatform_site.default_view_templates.content.embed%"
                 match: []

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -1,18 +1,6 @@
 imports:
     - { resource: services/templating.yml }
 
-parameters:
-    # Template defaults for standard eZ Platform installation
-    # By default we don't override URL alias view action, for that reason these are commented out
-    #ezplatform.default_view_templates.content.full: 'NetgenEzPlatformSiteApiBundle:default:content/full.html.twig'
-    #ezsettings.default.pagelayout: 'NetgenEzPlatformSiteApiBundle::pagelayout.html.twig'
-
-    # Defaults for semantic configuration
-    netgen_ez_platform_site_api.default.override_url_alias_view_action: false
-    netgen_ez_platform_site_api.default.use_always_available_fallback: true
-    netgen_ez_platform_site_api.default.fail_on_missing_fields: '%kernel.debug%'
-    netgen_ez_platform_site_api.default.render_missing_field_info: false
-
 services:
     netgen.ezplatform_site.controller.base:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\Controller\Controller

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -45,5 +45,4 @@ services:
             - 'ngcontent_view_defaults'
         calls:
             - [setContainer, ["@service_container"]]
-
         public: false

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -1,6 +1,3 @@
-parameters:
-    ezsettings.default.ng_named_query: {}
-
 services:
     netgen.ezplatform_site.view_builder.content:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\View\Builder\ContentViewBuilder

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -42,7 +42,7 @@ services:
             - '@ezpublish.api.repository'
             - 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased'
             - '@ezpublish.config.resolver'
-            - 'content_view_defaults'
+            - 'ngcontent_view_defaults'
         calls:
             - [setContainer, ["@service_container"]]
         public: false

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -45,4 +45,5 @@ services:
             - 'ngcontent_view_defaults'
         calls:
             - [setContainer, ["@service_container"]]
+
         public: false

--- a/bundle/Resources/views/default/content/asset_image.html.twig
+++ b/bundle/Resources/views/default/content/asset_image.html.twig
@@ -1,5 +1,11 @@
-{% set image_field_identifier = ez_content_field_identifier_image_asset() %}
+{% set config = ezpublish.configResolver.parameter('fieldtypes.ezimageasset.mappings') %}
+{% set image_field = content.fields[config['content_field_identifier']] %}
 
 {% if image_field_identifier is not null %}
-    {{ ng_render_field(content.fields[image_field_identifier], {parameters: parameters}) }}
+    {{ ng_render_field(
+        image_field,
+        {
+            parameters: parameters|default({'alias': 'original'})|merge({'alternativeText': image_field.value.alternativeText })
+        }
+    ) }}
 {% endif %}

--- a/bundle/Resources/views/default/content/asset_image.html.twig
+++ b/bundle/Resources/views/default/content/asset_image.html.twig
@@ -1,0 +1,5 @@
+{% set image_field_identifier = ez_content_field_identifier_image_asset() %}
+
+{% if image_field_identifier is not null %}
+    {{ ng_render_field(content.fields[image_field_identifier], {parameters: parameters}) }}
+{% endif %}

--- a/bundle/Resources/views/default/content/asset_image.html.twig
+++ b/bundle/Resources/views/default/content/asset_image.html.twig
@@ -1,7 +1,7 @@
 {% set config = ezpublish.configResolver.parameter('fieldtypes.ezimageasset.mappings') %}
 {% set image_field = content.fields[config['content_field_identifier']] %}
 
-{% if image_field_identifier is not null %}
+{% if image_field is not null %}
     {{ ng_render_field(
         image_field,
         {

--- a/bundle/Resources/views/default/content/embed.html.twig
+++ b/bundle/Resources/views/default/content/embed.html.twig
@@ -1,0 +1,5 @@
+{% if location is defined %}
+    <h3><a href="{{ path(location) }}">{{ content.name }}</a></h3>
+{% else %}
+    <h3><a href="{{ path(content) }}">{{ content.name }}</a></h3>
+{% endif %}

--- a/bundle/Resources/views/default/content/embed_image.html.twig
+++ b/bundle/Resources/views/default/content/embed_image.html.twig
@@ -1,8 +1,14 @@
-{% set image_field_identifier = ez_content_field_identifier_first_filled_image(content) %}
+{% set image_field = null %}
 
-{% if image_field_identifier is not null %}
+{% for field in content.fields %}
+    {% if image_field is null and field.fieldTypeIdentifier == 'ezimage' and not field.empty %}
+        {% set image_field = field %}
+    {% endif %}
+{% endfor %}
+
+{% if image_field is not null %}
     {{ ng_render_field(
-        content.fields[image_field_identifier],
+        image_field,
         {
             parameters: {
                 alias: objectParameters.size|default('original'),

--- a/bundle/Resources/views/default/content/embed_image.html.twig
+++ b/bundle/Resources/views/default/content/embed_image.html.twig
@@ -1,0 +1,13 @@
+{% set image_field_identifier = ez_content_field_identifier_first_filled_image(content) %}
+
+{% if image_field_identifier is not null %}
+    {{ ng_render_field(
+        content.fields[image_field_identifier],
+        {
+            parameters: {
+                alias: objectParameters.size|default('original'),
+                ezlink: linkParameters|default({})
+            }
+        }
+    ) }}
+{% endif %}

--- a/bundle/Resources/views/default/content/embed_inline.html.twig
+++ b/bundle/Resources/views/default/content/embed_inline.html.twig
@@ -1,0 +1,5 @@
+{% if location is defined %}
+    <a href="{{ path(location) }}"{% if class is defined %} class="{{ class }}"{% endif %}>{{ content.name }}</a>
+{% else %}
+    <a href="{{ path(content) }}"{% if class is defined %} class="{{ class }}"{% endif %}>{{ content.name }}</a>
+{% endif %}

--- a/bundle/Resources/views/default/content/full.html.twig
+++ b/bundle/Resources/views/default/content/full.html.twig
@@ -4,7 +4,7 @@
         summary:hover {background: wheat; cursor: pointer;}
         code {background-color: whitesmoke; padding: 2px; position: relative;}
         code:not(.empty):hover {cursor: pointer; background-color: lightgreen;}
-        code:not(.empty)::after{
+        code:not(.empty)::after {
             content: "click to copy";
             display:none;
             white-space: nowrap;

--- a/bundle/Resources/views/default/content/full.html.twig
+++ b/bundle/Resources/views/default/content/full.html.twig
@@ -41,7 +41,7 @@
             {% endif %}
         </dd>
         <dt>Current version</dt>
-        <dd><code onclick="copyText(this)">{{ content.contentInfo.currentVersionNo }}</code></dd>
+        <dd><code onclick="copyText(this)">{{ content.innerVersionInfo.versionNo }}</code></dd>
         <dt>Content type</dt>
         <dd><code onclick="copyText(this)">{{ content.contentInfo.contentTypeIdentifier }}</code></dd>
     </dl>

--- a/bundle/Resources/views/default/content/full.html.twig
+++ b/bundle/Resources/views/default/content/full.html.twig
@@ -1,6 +1,7 @@
 {% extends noLayout == true ? viewbaseLayout : '@NetgenEzPlatformSiteApi/pagelayout.html.twig' %}
 {% block content %}
     <style type='text/css'>
+        body {background: white;}
         summary:hover {background: wheat; cursor: pointer;}
         code {background-color: whitesmoke; padding: 2px; position: relative;}
         code:not(.empty):hover {cursor: pointer; background-color: lightgreen;}

--- a/bundle/Resources/views/default/content/full.html.twig
+++ b/bundle/Resources/views/default/content/full.html.twig
@@ -1,12 +1,85 @@
-{% extends noLayout == true ? viewbaseLayout : pagelayout %}
+{% extends noLayout == true ? viewbaseLayout : '@NetgenEzPlatformSiteApi/pagelayout.html.twig' %}
 {% block content %}
-    <h1>{{ content.name }} [{{ content.contentInfo.contentTypeIdentifier }}]</h1>
+    <style type='text/css'>
+        summary:hover {background: wheat; cursor: pointer;}
+        code {background-color: whitesmoke; padding: 2px; position: relative;}
+        code:not(.empty):hover {cursor: pointer; background-color: lightgreen;}
+        code:not(.empty)::after{
+            content: "click to copy";
+            display:none;
+            white-space: nowrap;
+            background-color: whitesmoke;
+            font-family: sans-serif;
+            font-size: 13px;
+        }
+        code:not(.empty):active::after {content: "copied"}
+        code:not(.empty):hover::after{position: absolute; left: calc(100% + 10px); display: inline}
+    </style>
+    <script type='application/javascript'>
+        function copyText(element) {
+            var aux = document.createElement('input');
+            aux.setAttribute('value', element.innerHTML);
+            document.body.appendChild(aux);
+            aux.select();
+            document.execCommand('copy');
+            document.body.removeChild(aux);
+        }
+    </script>
+
+    <h1>{{ content.name }}</h1>
+
+    <dl>
+        <dt>ID</dt>
+        <dd><code onclick="copyText(this)">{{ content.id }}</code></dd>
+        <dt>Location ID</dt>
+        <dd>
+            {% if location is defined %}
+                <code onclick="copyText(this)">{{ location.id }}</code>
+            {% else %}
+                <code class="empty">[empty]</code>
+            {% endif %}
+        </dd>
+        <dt>Current version</dt>
+        <dd><code onclick="copyText(this)">{{ content.contentInfo.currentVersionNo }}</code></dd>
+        <dt>Content type</dt>
+        <dd><code onclick="copyText(this)">{{ content.contentInfo.contentTypeIdentifier }}</code></dd>
+    </dl>
+
+    <h3>Fields</h3>
+
     {% for identifier, field in content.fields %}
-        <h3>{{ field.name }} [{{ identifier }}/{{ field.fieldTypeIdentifier }}]</h3>
-        {% if not field.isEmpty() %}
-            {{ ng_render_field(field) }}
-        {% else %}
-            <p>Field is empty.</p>
-        {% endif %}
+        <details>
+            <summary>{{ loop.index }}. {{ field.name }}</summary>
+            <blockquote>
+                <dl>
+                    <dt>ID</dt>
+                    <dd><code onclick="copyText(this)">{{ field.id }}</code></dd>
+                    <dt>Field definition ID</dt>
+                    <dd><code onclick="copyText(this)">{{ field.innerFieldDefinition.id }}</code></dd>
+                    <dt>Identifier</dt>
+                    <dd><code onclick="copyText(this)">{{ identifier }}</code></dd>
+                    <dt>Field type identifier</dt>
+                    <dd><code onclick="copyText(this)">{{ field.fieldTypeIdentifier }}</code></dd>
+                    <dt>Description</dt>
+                    <dd>
+                        {% if field.description is not empty %}
+                            {{ field.description|default('<code>[empty]</code>') }}
+                        {% else %}
+                            <code class="empty">[empty]</code>
+                        {% endif %}
+                    </dd>
+                    <dt>Contents</dt>
+                    <dd>
+                        {% if not field.isEmpty() %}
+                            <hr>
+                            {{ ng_render_field(field) }}
+                            <hr>
+                        {% else %}
+                            <code class="empty">[empty]</code>
+                        {% endif %}
+                    </dd>
+                </dl>
+            </blockquote>
+        </details>
     {% endfor %}
 {% endblock %}

--- a/bundle/Resources/views/default/content/full.html.twig
+++ b/bundle/Resources/views/default/content/full.html.twig
@@ -71,7 +71,7 @@
                     </dd>
                     <dt>Contents</dt>
                     <dd>
-                        {% if not field.isEmpty() %}
+                        {% if not field.empty %}
                             <hr>
                             {{ ng_render_field(field) }}
                             <hr>

--- a/bundle/Resources/views/default/content/line.html.twig
+++ b/bundle/Resources/views/default/content/line.html.twig
@@ -1,0 +1,5 @@
+{% if location is defined %}
+    <p><a href="{{ path(location) }}">{{ content.name }}</a></p>
+{% else %}
+    <p><a href="{{ path(content) }}">{{ content.name }}</a></p>
+{% endif %}

--- a/bundle/Resources/views/default/content/text_linked.html.twig
+++ b/bundle/Resources/views/default/content/text_linked.html.twig
@@ -1,0 +1,5 @@
+{% if location is defined %}
+    <a href="{{ path(location) }}">{{ content.name }}</a>
+{% else %}
+    <a href="{{ path(content) }}">{{ content.name }}</a>
+{% endif %}

--- a/bundle/Resources/views/pagelayout.html.twig
+++ b/bundle/Resources/views/pagelayout.html.twig
@@ -1,14 +1,20 @@
 <!doctype html>
-<html lang="{{ app.request.locale|replace('_', '-') }}">
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
 <head>
     <meta charset="utf-8">
     <title>{{ content.name|default( 'Home' ) }}</title>
     <meta name="generator" content="eZ Platform"/>
-    {% if content is defined and content.mainLocationId %}
-        <link rel="canonical" href="{{ path( 'ez_urlalias', {'locationId': content.mainLocationId} ) }}" />
+    {% if content is defined and content.mainLocation is not null %}
+        <link rel="canonical" href="{{ path( content.mainLocation ) }}" />
     {% endif %}
 </head>
 <body>
 {% block content %}{% endblock %}
+<footer>
+    <hr>
+    <p>
+        <a href="https://docs.netgen.io/projects/site-api">Site API documentation</a>
+    </p>
+</footer>
 </body>
 </html>

--- a/docs/reference/migration.rst
+++ b/docs/reference/migration.rst
@@ -46,6 +46,14 @@ expect that things will break. Similar to the point 2. from above will be valid 
 view configuration, available under ``content_view`` key. You will still be able to use it, but only
 through explicit subrequests to eZ Platform's view controller ``ez_content:viewAction``.
 
+In eZ Platform pagelayout is configured separately from content view configuration. The configured
+pagelayout is available in the content view templates as ``pagelayout`` variable, which is usually
+extended in full view templates. When using both views at the same time, you will have to choose
+which one to support with your configured pagelayout - eZ Platform with its Content and Location
+objects, or Site API with its own Content and Location counterparts. Whichever you choose, you can
+support the other one by defining the pagelayout explicitly, instead using it through a configured
+variable.
+
 All Site API objects contain their eZ Platform counterparts. This will enable initial mixing of both
 Site API and vanilla eZ Platform ways of doing things, which means you will be able to migrate your
 project one step at a time.


### PR DESCRIPTION
This adds Site API versions of default view templates [from eZ Platform kernel](https://github.com/ezsystems/ezpublish-kernel/tree/master/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content). In eZ Platform some of these (asset image, embed image, text linked) are only used from content field templates. Since we reuse the default content field templates, it was not strictly necessary to add all of them, I did it for the sake of completeness in case someone does depend on them being available.

All of these are now configured with the default template view provider, which previously used the templates/configuration from eZ Platform.

Additionally I improved the default full view template to be more useful.