### PR TITLE
Fix draft preview

### DIFF
--- a/bundle/Controller/PreviewController.php
+++ b/bundle/Controller/PreviewController.php
@@ -53,7 +53,8 @@ class PreviewController extends BasePreviewController
 
         $overrideViewAction = $this->configResolver->getParameter(
             'override_url_alias_view_action',
-            'netgen_ez_platform_site_api'
+            'netgen_ez_platform_site_api',
+            $previewSiteAccess->name
         );
 
         // If the preview siteaccess is configured in legacy_mode

--- a/bundle/Matcher/MatcherFactory.php
+++ b/bundle/Matcher/MatcherFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Matcher;
+
+use eZ\Bundle\EzPublishCoreBundle\Matcher\ServiceAwareMatcherFactory;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+class MatcherFactory extends ServiceAwareMatcherFactory
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var string
+     */
+    private $parameterName;
+
+    /**
+     * @var string|null
+     */
+    private $namespace;
+
+    /**
+     * @var string|null
+     */
+    private $scope;
+
+    public function __construct(
+        Repository $repository,
+        string $relativeNamespace,
+        ConfigResolverInterface $configResolver,
+        string $parameterName,
+        ?string $namespace = null,
+        ?string $scope = null
+    ) {
+        $this->configResolver = $configResolver;
+        $this->parameterName = $parameterName;
+        $this->namespace = $namespace;
+        $this->scope = $scope;
+
+        parent::__construct($repository, $relativeNamespace);
+    }
+
+    public function match(View $view): ?array
+    {
+        $matchConfig = $this->configResolver->getParameter($this->parameterName, $this->namespace, $this->scope);
+        $this->setMatchConfig($matchConfig);
+
+        return parent::match($view);
+    }
+}

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -21,13 +21,14 @@ services:
         public: false
 
     netgen.ezplatform_site.ngcontent_view.matcher_factory:
-        class: eZ\Bundle\EzPublishCoreBundle\Matcher\ServiceAwareMatcherFactory
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Matcher\MatcherFactory
         arguments:
             - '@ezpublish.api.repository'
             - 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased'
+            - '@ezpublish.config.resolver'
+            - 'ngcontent_view'
         calls:
             - [setContainer, ["@service_container"]]
-            - [setMatchConfig, [$ngcontent_view$]]
         public: false
 
     netgen.ezplatform_site.ngcontent_view_provider.default_configured:
@@ -39,11 +40,12 @@ services:
         public: false
 
     netgen.ezplatform_site.ngcontent_view.default_matcher_factory:
-        class: eZ\Bundle\EzPublishCoreBundle\Matcher\ServiceAwareMatcherFactory
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\Matcher\MatcherFactory
         arguments:
             - '@ezpublish.api.repository'
             - 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased'
+            - '@ezpublish.config.resolver'
+            - 'content_view_defaults'
         calls:
             - [setContainer, ["@service_container"]]
-            - [setMatchConfig, [$content_view_defaults$]]
         public: false


### PR DESCRIPTION
This fixes the draft preview, both in Netgen Admin UI and eZ Platform Admin UI. The preview was not working because the view Matcher config for the preview siteaccess was not set to the Matcher. This is now done through our local implementation of the Matcher factory, which uses ConfigResolver directly, as was recently introduced in kernel in https://github.com/ezsystems/ezpublish-kernel/pull/2673 (for eZ Platform v3 only).

This also gets us rid of using dynamic settings.