### PR TITLE
Content render events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ branches:
     only:
         - master
         - 2.7-release
+        - 3.0-release
 
 # make sure to update composer to latest available version
 before_install:

--- a/bundle/EventListener/ContentTaggerListener.php
+++ b/bundle/EventListener/ContentTaggerListener.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\EventListener;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use Netgen\EzPlatformSiteApi\Event\RenderContentEvent;
+use Netgen\EzPlatformSiteApi\Event\SiteApiEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ContentTaggerListener implements EventSubscriberInterface
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger
+     */
+    private $responseTagger;
+
+    public function __construct(ResponseTagger $responseTagger)
+    {
+        $this->responseTagger = $responseTagger;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [SiteApiEvents::RENDER_CONTENT => 'onRenderContent'];
+    }
+
+    public function onRenderContent(RenderContentEvent $event): void
+    {
+        $this->responseTagger->tag($event->getView());
+    }
+}

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -82,3 +82,10 @@ services:
             - '@netgen.ezplatform_site.load_service'
         tags:
             - { name: request.param_converter, priority: -1 }
+
+    netgen.ezplatform_site.event_listener.content_tagger:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\EventListener\ContentTaggerListener
+        arguments:
+            - '@ezplatform.view_cache.response_tagger.dispatcher'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/bundle/Resources/config/services/templating.yml
+++ b/bundle/Resources/config/services/templating.yml
@@ -31,6 +31,7 @@ services:
             - '@netgen.ezplatform_site.view_builder.content'
             - '@ezpublish.view.template_renderer'
             - '@ezpublish.api.service.location'
+            - '@event_dispatcher'
         tags:
             - { name: twig.runtime }
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "~7.1",
         "ezsystems/ezpublish-kernel": "^7.4 || ^8.0",
+        "ezsystems/ezplatform-http-cache": ">=0.8, <1.0 || ^1.0",
         "netgen/ezplatform-search-extra": "^1.8",
         "sensio/framework-extra-bundle": "^5.2"
     },

--- a/lib/Event/RenderContentEvent.php
+++ b/lib/Event/RenderContentEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSiteApi\Event;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Component\EventDispatcher\Event;
+
+final class RenderContentEvent extends Event
+{
+    /**
+     * View object that was rendered.
+     *
+     * @var \eZ\Publish\Core\MVC\Symfony\View\View
+     */
+    private $view;
+
+    public function __construct(View $view)
+    {
+        $this->view = $view;
+    }
+
+    public function getView(): View
+    {
+        return $this->view;
+    }
+}

--- a/lib/Event/SiteApiEvents.php
+++ b/lib/Event/SiteApiEvents.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSiteApi\Event;
+
+final class SiteApiEvents
+{
+    /**
+     * Dispatched when the content is rendered without usage of sub-requests.
+     */
+    public const RENDER_CONTENT = 'netgen_site_api.render_content';
+}


### PR DESCRIPTION
Since direct content rendering does not execute event listeners for subrequests ( since there are no subrequests :) ), some important stuff might be missing in the final page rendering.

For this reason, this adds an event that can be used to bring back custom functionality when rendering content without subrequests.

Additionally, this also adds a listener for said event which tags the master request with `xkey` tags relevant to content rendered without subrequests, which is normally done via `EzSystems\PlatformHttpCacheBundle\EventSubscriber\HttpCacheResponseSubscriber`. Not having the tags, and not having a working HTTP cache clear was the whole motivation behind this.