### PR TITLE
Reset ezsettings parameters only if they do not exist

### DIFF
--- a/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
@@ -57,6 +57,14 @@ class NetgenEzPlatformSiteApiExtension extends Extension implements PrependExten
         $loader->load('services.yml');
         $loader->load('view.yml');
 
+        if (!$container->hasParameter('ezsettings.default.ngcontent_view')) {
+            $container->setParameter('ezsettings.default.ngcontent_view', []);
+        }
+
+        if (!$container->hasParameter('ezsettings.default.ng_named_query')) {
+            $container->setParameter('ezsettings.default.ng_named_query', []);
+        }
+
         $processor = new ConfigurationProcessor($container, $this->getAlias());
         $processor->mapConfig(
             $config,

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -17,8 +17,6 @@ parameters:
     netgen.ezplatform_site.content_view.image_embed_content_type_identifiers: ['image']
 
     # Default eZ Platform settings
-    ezsettings.default.ng_named_query: {}
-    ezsettings.default.ngcontent_view: {}
     # By default we don't override URL alias view action, for that reason this is commented out
     #ezsettings.default.pagelayout: '@@NetgenEzPlatformSiteApi/pagelayout.html.twig'
 


### PR DESCRIPTION
Consider the following:

```
ezpublish:
    system:
        default:
            ngcontent_view:
                full:
                    article:
                        template: "@ezdesign/content/full/article.html.twig"
                        match:
                            Identifier\ContentType: article
```

Since eZ kernel bundle is most of the time activated before Site API bundle, this semantic configuration is processed and merged, and the internal eZ kernel parameter for the above config (`ezsettings.default.ngcontent_view`) is set, all before Site API DI extension is ran.

When Site API DI extension is ran, this causes the extension to overwrite the internal eZ kernel parameter to an empty value, even if eZ kernel already processed and merged the config.

This PR fixes this so the default value of the internal parameter is set only if there no parameter in the container yet. The basic issue here is that the semantic config is part of the eZ kernel bundles (or rather, DI extension with `ezpublish` alias) and not part of the Site API DI extension, making this a chicken or the egg situation.

Same principle applies to `ng_named_query` config.