### PR TITLE
Cleanup setting default config values

### DIFF
--- a/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
@@ -74,12 +74,6 @@ class NetgenEzPlatformSiteApiExtension extends Extension implements PrependExten
                 }
             }
         );
-
-        if (!$container->hasParameter('ezsettings.default.ngcontent_view')) {
-            // Default value for ngcontent_view template rules
-            // Setting this through the config file causes issues in eZ kernel 6.11+
-            $container->setParameter('ezsettings.default.ngcontent_view', []);
-        }
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
@@ -57,13 +57,7 @@ class NetgenEzPlatformSiteApiExtension extends Extension implements PrependExten
         $loader->load('services.yml');
         $loader->load('view.yml');
 
-        if (!$container->hasParameter('ezsettings.default.ngcontent_view')) {
-            $container->setParameter('ezsettings.default.ngcontent_view', []);
-        }
-
-        if (!$container->hasParameter('ezsettings.default.ng_named_query')) {
-            $container->setParameter('ezsettings.default.ng_named_query', []);
-        }
+        $this->setDefaultValuesIfNeeded($container);
 
         $processor = new ConfigurationProcessor($container, $this->getAlias());
         $processor->mapConfig(
@@ -74,6 +68,24 @@ class NetgenEzPlatformSiteApiExtension extends Extension implements PrependExten
                 }
             }
         );
+    }
+
+    /**
+     * Default values must be set conditionally because eZ Kernel bundles are usually activated
+     * before this extension is ran. In that case the values that were already processed and merged
+     * to the container would be overwritten with the default value.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    private function setDefaultValuesIfNeeded(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('ezsettings.default.ngcontent_view')) {
+            $container->setParameter('ezsettings.default.ngcontent_view', []);
+        }
+
+        if (!$container->hasParameter('ezsettings.default.ng_named_query')) {
+            $container->setParameter('ezsettings.default.ng_named_query', []);
+        }
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSiteApiExtension.php
@@ -70,6 +70,15 @@ class NetgenEzPlatformSiteApiExtension extends Extension implements PrependExten
         );
     }
 
+    public function prepend(ContainerBuilder $container): void
+    {
+        $configFile = __DIR__ . '/../Resources/config/ezplatform.yml';
+        $config = Yaml::parse(\file_get_contents($configFile));
+        $container->addResource(new FileResource($configFile));
+
+        $container->prependExtensionConfig('ezpublish', $config);
+    }
+
     /**
      * Default values must be set conditionally because eZ Kernel bundles are usually activated
      * before this extension is ran. In that case the values that were already processed and merged
@@ -86,14 +95,5 @@ class NetgenEzPlatformSiteApiExtension extends Extension implements PrependExten
         if (!$container->hasParameter('ezsettings.default.ng_named_query')) {
             $container->setParameter('ezsettings.default.ng_named_query', []);
         }
-    }
-
-    public function prepend(ContainerBuilder $container): void
-    {
-        $configFile = __DIR__ . '/../Resources/config/ezplatform.yml';
-        $config = Yaml::parse(\file_get_contents($configFile));
-        $container->addResource(new FileResource($configFile));
-
-        $container->prependExtensionConfig('ezpublish', $config);
     }
 }


### PR DESCRIPTION
This removes setting default values introduced in https://github.com/netgen/ezplatform-site-api/commit/12ca1bae062e27258a438b74e7cb68d6708ea2e1, since it seems it was about the same problem fixed in https://github.com/netgen/ezplatform-site-api/pull/142.

Additionally it extracts setting default values into a separate documented method.