### PR TITLE
Remove configuration for the default full view

### DIFF
--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -37,10 +37,12 @@ parameters:
             default:
                 template: "%netgen.ezplatform_site.default_view_templates.content.embed_inline%"
                 match: []
-        full:
-            default:
-                template: "%netgen.ezplatform_site.default_view_templates.content.full%"
-                match: []
+        # Default full view is intentionally disabled because for some cases we depend on Content
+        # redirecting to the homepage when the full view is not configured.
+        #full:
+        #    default:
+        #        template: "%netgen.ezplatform_site.default_view_templates.content.full%"
+        #        match: []
         line:
             default:
                 template: "%netgen.ezplatform_site.default_view_templates.content.line%"


### PR DESCRIPTION
This removes default full view configuration because some Content does not have a full view.
For some cases we depend on the default behavior, which redirects such route to the homepage.