### PR TITLE
NGSTACK-347 enable redirects through content view configuration

### DIFF
--- a/bundle/DependencyInjection/Compiler/InvalidConfigurationListenerPass.php
+++ b/bundle/DependencyInjection/Compiler/InvalidConfigurationListenerPass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class InvalidConfigurationListenerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('netgen.ezplatform_site.event_listener.invalid_configuration')) {
+            return;
+        }
+
+        if ($container->getParameter('kernel.debug') === false) {
+            return;
+        }
+
+        $container->removeDefinition('netgen.ezplatform_site.event_listener.invalid_configuration');
+    }
+}

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -39,7 +39,7 @@ class ContentView extends AbstractParser
                                     && !\array_key_exists('redirect', $v);
                             })
                             ->then(function($v) {
-                                $value = \array_key_exists('permanent_redirect', $v) ? $v['permanent_redirect'] : $v['temporary_redirect'];
+                                $value = $v['permanent_redirect'] ?? $v['temporary_redirect'];
                                 $permanent = \array_key_exists('permanent_redirect', $v);
 
                                 $v['redirect'] = [

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -101,7 +101,7 @@ EOT
                         ->end()
                         ->validate()
                             ->ifTrue(static function ($v): bool {
-                                if  (\array_key_exists('redirect', $v)) {
+                                if (\array_key_exists('redirect', $v)) {
                                     return \array_key_exists('controller', $v) || \array_key_exists('template', $v);
                                 }
 
@@ -113,7 +113,7 @@ EOT
                         ->end()
                         ->validate()
                             ->ifTrue(static function ($v): bool {
-                                if  (\array_key_exists('redirect', $v)) {
+                                if (\array_key_exists('redirect', $v)) {
                                     return \array_key_exists('temporary_redirect', $v) || \array_key_exists('permanent_redirect', $v);
                                 }
 

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -50,7 +50,7 @@ EOT
                                         ->isRequired()
                                         ->cannotBeEmpty()
                                     ->end()
-                                    ->scalarNode('permanent')
+                                    ->booleanNode('permanent')
                                         ->defaultFalse()
                                     ->end()
                                     ->arrayNode('target_parameters')

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -35,7 +35,8 @@ class ContentView extends AbstractParser
                     ->arrayPrototype()
                         ->beforeNormalization()
                             ->ifTrue(function($v) {
-                                return \array_key_exists('permanent_redirect', $v) || \array_key_exists('temporary_redirect', $v);
+                                return (\array_key_exists('permanent_redirect', $v) xor \array_key_exists('temporary_redirect', $v))
+                                    && !\array_key_exists('redirect', $v);
                             })
                             ->then(function($v) {
                                 $value = \array_key_exists('permanent_redirect', $v) ? $v['permanent_redirect'] : $v['temporary_redirect'];
@@ -46,11 +47,7 @@ class ContentView extends AbstractParser
                                     'permanent' => $permanent
                                 ];
 
-                                if ($permanent) {
-                                    unset($v['permanent_redirect']);
-                                } else {
-                                    unset($v['temporary_redirect']);
-                                }
+                                unset($v['permanent_redirect'], $v['temporary_redirect']);
 
                                 return $v;
                             })

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -44,7 +44,8 @@ class ContentView extends AbstractParser
 
                                 $v['redirect'] = [
                                     'target' => $value,
-                                    'permanent' => $permanent
+                                    'permanent' => $permanent,
+                                    'absolute' => false,
                                 ];
 
                                 unset($v['permanent_redirect'], $v['temporary_redirect']);
@@ -70,6 +71,9 @@ EOT
                                         ->cannotBeEmpty()
                                     ->end()
                                     ->booleanNode('permanent')
+                                        ->defaultFalse()
+                                    ->end()
+                                    ->booleanNode('absolute')
                                         ->defaultFalse()
                                     ->end()
                                     ->arrayNode('target_parameters')

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -64,7 +64,7 @@ EOT
                                 )
                                 ->example('MyBundle:MyControllerClass:view')
                             ->end()
-                            ->arrayNode('redirect') // @todo: add validation
+                            ->arrayNode('redirect')
                                 ->children()
                                     ->scalarNode('target')
                                         ->isRequired()

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -33,6 +33,28 @@ class ContentView extends AbstractParser
                     ->normalizeKeys(false)
                     ->info("View selection rulesets, grouped by view type. Key is the view type (e.g. 'full', 'line', ...)")
                     ->arrayPrototype()
+                        ->beforeNormalization()
+                            ->ifTrue(function($v) {
+                                return \array_key_exists('permanent_redirect', $v) || \array_key_exists('temporary_redirect', $v);
+                            })
+                            ->then(function($v) {
+                                $value = \array_key_exists('permanent_redirect', $v) ? $v['permanent_redirect'] : $v['temporary_redirect'];
+                                $permanent = \array_key_exists('permanent_redirect', $v);
+
+                                $v['redirect'] = [
+                                    'target' => $value,
+                                    'permanent' => $permanent
+                                ];
+
+                                if ($permanent) {
+                                    unset($v['permanent_redirect']);
+                                } else {
+                                    unset($v['temporary_redirect']);
+                                }
+
+                                return $v;
+                            })
+                        ->end()
                         ->children()
                             ->scalarNode('template')->info('Your template path, as @App/my_template.html.twig')->end()
                             ->scalarNode('controller')

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -44,6 +44,21 @@ EOT
                                 )
                                 ->example('MyBundle:MyControllerClass:view')
                             ->end()
+                            ->arrayNode('redirect') // @todo: add validation
+                                ->children()
+                                    ->scalarNode('target')
+                                        ->isRequired()
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                    ->scalarNode('permanent')
+                                        ->defaultFalse()
+                                    ->end()
+                                    ->arrayNode('target_parameters')
+                                        ->useAttributeAsKey('key')
+                                        ->variablePrototype()->end()
+                                    ->end()
+                                ->end()
+                            ->end()
                             ->scalarNode('permanent_redirect')
                             ->info(
                                 <<<'EOT'
@@ -83,6 +98,30 @@ EOT
                                 ->useAttributeAsKey('key')
                                 ->variablePrototype()->end()
                             ->end()
+                        ->end()
+                        ->validate()
+                            ->ifTrue(static function ($v): bool {
+                                if  (\array_key_exists('redirect', $v)) {
+                                    return \array_key_exists('controller', $v) || \array_key_exists('template', $v);
+                                }
+
+                                return false;
+                            })
+                            ->thenInvalid(
+                                'You cannot use both redirect and controller/template configuration at the same time.'
+                            )
+                        ->end()
+                        ->validate()
+                            ->ifTrue(static function ($v): bool {
+                                if  (\array_key_exists('redirect', $v)) {
+                                    return \array_key_exists('temporary_redirect', $v) || \array_key_exists('permanent_redirect', $v);
+                                }
+
+                                return false;
+                            })
+                            ->thenInvalid(
+                                'You cannot use both expanded and shortcut redirect configuration at the same time.'
+                            )
                         ->end()
                         ->validate()
                             ->ifTrue(static function ($v): bool {

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -44,6 +44,22 @@ EOT
                                 )
                                 ->example('MyBundle:MyControllerClass:view')
                             ->end()
+                            ->scalarNode('permanent_redirect')
+                            ->info(
+                                <<<'EOT'
+Set up permanent redirect. You can use the expression language here as well.
+EOT
+                            )
+                            ->example('@=location.parent')
+                            ->end()
+                            ->scalarNode('temporary_redirect')
+                            ->info(
+                                <<<'EOT'
+Set up temporary redirect. You can use the expression language here as well.
+EOT
+                            )
+                            ->example('@=location.parent')
+                            ->end()
                             ->arrayNode('match')
                                 ->info('Condition matchers configuration')
                                 ->isRequired()
@@ -67,6 +83,26 @@ EOT
                                 ->useAttributeAsKey('key')
                                 ->variablePrototype()->end()
                             ->end()
+                        ->end()
+                        ->validate()
+                            ->ifTrue(static function ($v): bool {
+                                return \array_key_exists('temporary_redirect', $v) && \array_key_exists('permanent_redirect', $v);
+                            })
+                            ->thenInvalid(
+                                'You cannot use both "temporary_redirect" and "permanent_redirect" at the same time.'
+                            )
+                        ->end()
+                        ->validate()
+                            ->ifTrue(static function ($v): bool {
+                                if (\array_key_exists('temporary_redirect', $v) || \array_key_exists('permanent_redirect', $v)) {
+                                    return \array_key_exists('controller', $v) || \array_key_exists('template', $v);
+                                }
+
+                                return false;
+                            })
+                            ->thenInvalid(
+                                'You cannot use both redirect and controller/template configuration at the same time.'
+                            )
                         ->end()
                     ->end()
                 ->end()

--- a/bundle/EventListener/InvalidConfigurationListener.php
+++ b/bundle/EventListener/InvalidConfigurationListener.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\EventListener;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Netgen\Bundle\EzPlatformSiteApiBundle\Exception\InvalidRedirectConfiguration;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class InvalidConfigurationListener implements EventSubscriberInterface
+{
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface
+     */
+    protected $urlGenerator;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    protected $configResolver;
+
+    /**
+     * InvalidConfigurationListener constructor.
+     *
+     * @param \Symfony\Component\Routing\Generator\UrlGeneratorInterface $urlGenerator
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     * @param \Psr\Log\LoggerInterface|null $logger
+     */
+    public function __construct(
+        UrlGeneratorInterface $urlGenerator,
+        ConfigResolverInterface $configResolver,
+        LoggerInterface $logger = null
+    ) {
+        $this->urlGenerator = $urlGenerator;
+        $this->configResolver = $configResolver;
+        $this->logger = $logger ?: new NullLogger();
+    }
+
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::EXCEPTION => 'onKernelException'];
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event): void
+    {
+        $exception = $event->getException();
+
+        if (!$exception instanceof InvalidRedirectConfiguration) {
+            return;
+        }
+
+        $this->logger->critical($exception->getMessage());
+
+        $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id');
+        $event->setResponse(
+            new RedirectResponse(
+                $this->urlGenerator->generate('ez_urlalias', ['locationId' => $rootLocationId]),
+                RedirectResponse::HTTP_FOUND
+            )
+        );
+    }
+}

--- a/bundle/Exception/InvalidRedirectConfiguration.php
+++ b/bundle/Exception/InvalidRedirectConfiguration.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Exception;
+
+use Throwable;
+
+final class InvalidRedirectConfiguration extends \Exception
+{
+    public function __construct(string $target)
+    {
+        $message = "Not possible to resolve redirect from given target: '{$target}'";
+
+        parent::__construct($message);
+    }
+}

--- a/bundle/NetgenEzPlatformSiteApiBundle.php
+++ b/bundle/NetgenEzPlatformSiteApiBundle.php
@@ -6,6 +6,7 @@ namespace Netgen\Bundle\EzPlatformSiteApiBundle;
 
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\AggregateRepositoryPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\DefaultViewActionOverridePass;
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\InvalidConfigurationListenerPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\PreviewControllerOverridePass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\ViewBuilderRegistrationPass;
@@ -25,6 +26,7 @@ class NetgenEzPlatformSiteApiBundle extends Bundle
         $container->addCompilerPass(new PreviewControllerOverridePass());
         $container->addCompilerPass(new RelationResolverRegistrationPass());
         $container->addCompilerPass(new ViewBuilderRegistrationPass());
+        $container->addCompilerPass(new InvalidConfigurationListenerPass());
 
         /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $coreExtension */
         $coreExtension = $container->getExtension('ezpublish');

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -90,3 +90,13 @@ services:
             - '@ezplatform.view_cache.response_tagger.dispatcher'
         tags:
             - { name: kernel.event_subscriber }
+
+    netgen.ezplatform_site.event_listener.invalid_configuration:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\EventListener\InvalidConfigurationListener
+        public: false
+        arguments:
+            - '@router'
+            - '@ezpublish.config.resolver'
+            - '@?logger'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -13,8 +13,22 @@ services:
         arguments:
             - '@netgen.ezplatform_site.ngcontent_view.matcher_factory'
             - '@netgen.ezplatform_site.query_type.query_definition_mapper'
+            - '@netgen.ezplatform_site.redirect_resolver'
         tags:
             - { name: ezpublish.view_provider, type: 'Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView', priority: 110 }
+        public: false
+
+    netgen.ezplatform_site.redirect_resolver:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect\Resolver
+        arguments:
+            - '@netgen.ezplatform_site.redirect.parameter_processor'
+            - '@router'
+
+    netgen.ezplatform_site.redirect.parameter_processor:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect\ParameterProcessor
+        arguments:
+            - '@ezpublish.config.resolver'
+            - '@netgen.ezplatform_site.named_object_provider'
         public: false
 
     netgen.ezplatform_site.ngcontent_view.matcher_factory:

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -23,11 +23,11 @@ services:
         arguments:
             - '@netgen.ezplatform_site.redirect.parameter_processor'
             - '@router'
+        public: false
 
     netgen.ezplatform_site.redirect.parameter_processor:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect\ParameterProcessor
         arguments:
-            - '@ezpublish.config.resolver'
             - '@netgen.ezplatform_site.named_object_provider'
         public: false
 

--- a/bundle/View/Provider/Configured.php
+++ b/bundle/View/Provider/Configured.php
@@ -149,13 +149,7 @@ class Configured implements ViewProvider
             )
         );
 
-        if (isset($viewConfig['redirect'])) {
-            $redirectConfig = RedirectConfiguration::fromConfigurationArray($viewConfig['redirect']);
-        } else if (isset($viewConfig['permanent_redirect'])) {
-            $redirectConfig = new RedirectConfiguration($viewConfig['permanent_redirect'], [], true);
-        } else if (isset($viewConfig['temporary_redirect'])) {
-            $redirectConfig = new RedirectConfiguration($viewConfig['temporary_redirect'], [], false);
-        }
+        $redirectConfig = $this->createRedirectConfiguration($viewConfig);
 
         $dto->addParameters(
             [
@@ -163,5 +157,17 @@ class Configured implements ViewProvider
                 'permanent' => $redirectConfig->isPermanent()
             ]
         );
+    }
+
+    private function createRedirectConfiguration(array $viewConfig): RedirectConfiguration
+    {
+        if (isset($viewConfig['redirect'])) {
+            return RedirectConfiguration::fromConfigurationArray($viewConfig['redirect']);
+        }
+
+        return isset($viewConfig['permanent_redirect']) ?
+            new RedirectConfiguration($viewConfig['permanent_redirect'], [], true) :
+            new RedirectConfiguration($viewConfig['temporary_redirect'], [], false)
+        ;
     }
 }

--- a/bundle/View/Provider/Configured.php
+++ b/bundle/View/Provider/Configured.php
@@ -139,7 +139,7 @@ class Configured implements ViewProvider
 
     private function processRedirects(CoreContentView $dto, array $viewConfig, ContentView $view)
     {
-        if (!isset($viewConfig['redirect']) && !isset($viewConfig['permanent_redirect']) && !isset($viewConfig['temporary_redirect'])) {
+        if (!isset($viewConfig['redirect'])) {
             return;
         }
 
@@ -149,7 +149,7 @@ class Configured implements ViewProvider
             )
         );
 
-        $redirectConfig = $this->createRedirectConfiguration($viewConfig);
+        $redirectConfig = RedirectConfiguration::fromConfigurationArray($viewConfig['redirect']);
 
         $dto->addParameters(
             [
@@ -157,16 +157,5 @@ class Configured implements ViewProvider
                 'permanent' => $redirectConfig->isPermanent(),
             ]
         );
-    }
-
-    private function createRedirectConfiguration(array $viewConfig): RedirectConfiguration
-    {
-        if (isset($viewConfig['redirect'])) {
-            return RedirectConfiguration::fromConfigurationArray($viewConfig['redirect']);
-        }
-
-        return isset($viewConfig['permanent_redirect']) ?
-            new RedirectConfiguration($viewConfig['permanent_redirect'], [], true) :
-            new RedirectConfiguration($viewConfig['temporary_redirect'], [], false);
     }
 }

--- a/bundle/View/Provider/Configured.php
+++ b/bundle/View/Provider/Configured.php
@@ -123,7 +123,7 @@ class Configured implements ViewProvider
         if (isset($viewConfig['permanent_redirect']) || isset($viewConfig['temporary_redirect'])) {
             $dto->setControllerReference(
                 new ControllerReference(
-                    'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction'
+                    sprintf('%s::%s', RedirectController::class, 'urlRedirectAction')
                 )
             );
 

--- a/bundle/View/Provider/Configured.php
+++ b/bundle/View/Provider/Configured.php
@@ -145,7 +145,7 @@ class Configured implements ViewProvider
 
         $dto->setControllerReference(
             new ControllerReference(
-                sprintf('%s::%s', RedirectController::class, 'urlRedirectAction')
+                \sprintf('%s::%s', RedirectController::class, 'urlRedirectAction')
             )
         );
 
@@ -154,7 +154,7 @@ class Configured implements ViewProvider
         $dto->addParameters(
             [
                 'path' => $this->redirectResolver->resolveTarget($redirectConfig, $view),
-                'permanent' => $redirectConfig->isPermanent()
+                'permanent' => $redirectConfig->isPermanent(),
             ]
         );
     }
@@ -167,7 +167,6 @@ class Configured implements ViewProvider
 
         return isset($viewConfig['permanent_redirect']) ?
             new RedirectConfiguration($viewConfig['permanent_redirect'], [], true) :
-            new RedirectConfiguration($viewConfig['temporary_redirect'], [], false)
-        ;
+            new RedirectConfiguration($viewConfig['temporary_redirect'], [], false);
     }
 }

--- a/bundle/View/Redirect/ParameterProcessor.php
+++ b/bundle/View/Redirect/ParameterProcessor.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider;
+use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+final class ParameterProcessor
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var \Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider
+     */
+    private $namedObjectProvider;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver,
+        Provider $namedObjectProvider
+    ) {
+        $this->configResolver = $configResolver;
+        $this->namedObjectProvider = $namedObjectProvider;
+    }
+
+    /**
+     * Return given $value processed with ExpressionLanguage if needed.
+     *
+     * Parameter $view is used to provide values for evaluation.
+     *
+     * @param mixed $value
+     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView $view
+     *
+     * @return mixed
+     */
+    public function process($value, ContentView $view)
+    {
+        if (!\is_string($value) || \strpos($value, '@=') !== 0) {
+            return $value;
+        }
+
+        $language = new ExpressionLanguage();
+
+        $this->registerFunctions($language);
+
+        return $language->evaluate(
+            \substr($value, 2),
+            [
+                'location' => $view->getSiteLocation(),
+                'content' => $view->getSiteContent(),
+                'configResolver' => $this->configResolver,
+                'namedObject' => $this->namedObjectProvider,
+            ]
+        );
+    }
+
+    /**
+     * Register functions with the given $expressionLanguage.
+     *
+     * @param \Symfony\Component\ExpressionLanguage\ExpressionLanguage $expressionLanguage
+     */
+    private function registerFunctions(ExpressionLanguage $expressionLanguage): void
+    {
+        $configResolver = $this->configResolver;
+
+        $expressionLanguage->register(
+            'config',
+            static function (): void {},
+            static function (array $arguments, string $name, ?string $namespace = null, ?string $scope = null) use ($configResolver) {
+                return $configResolver->getParameter($name, $namespace, $scope);
+            }
+        );
+
+        $namedObjectProvider = $this->namedObjectProvider;
+
+        $expressionLanguage->register(
+            'namedContent',
+            static function (): void {},
+            static function (array $arguments, string $name) use ($namedObjectProvider) {
+                return $namedObjectProvider->getContent($name);
+            }
+        );
+
+        $expressionLanguage->register(
+            'namedLocation',
+            static function (): void {},
+            static function (array $arguments, string $name) use ($namedObjectProvider) {
+                return $namedObjectProvider->getLocation($name);
+            }
+        );
+    }
+
+}

--- a/bundle/View/Redirect/ParameterProcessor.php
+++ b/bundle/View/Redirect/ParameterProcessor.php
@@ -58,29 +58,27 @@ final class ParameterProcessor
      */
     private function registerFunctions(ExpressionLanguage $expressionLanguage): void
     {
-        $namedObjectProvider = $this->namedObjectProvider;
-
         $expressionLanguage->register(
             'namedContent',
-            static function (): void {},
-            static function (array $arguments, string $name) use ($namedObjectProvider) {
-                return $namedObjectProvider->getContent($name);
+            function (): void {},
+            function (array $arguments, string $name) {
+                return $this->namedObjectProvider->getContent($name);
             }
         );
 
         $expressionLanguage->register(
             'namedLocation',
-            static function (): void {},
-            static function (array $arguments, string $name) use ($namedObjectProvider) {
-                return $namedObjectProvider->getLocation($name);
+            function (): void {},
+            function (array $arguments, string $name) {
+                return $this->namedObjectProvider->getLocation($name);
             }
         );
 
         $expressionLanguage->register(
             'namedTag',
-            static function (): void {},
-            static function (array $arguments, string $name) use ($namedObjectProvider) {
-                return $namedObjectProvider->getTag($name);
+            function (): void {},
+            function (array $arguments, string $name) {
+                return $this->namedObjectProvider->getTag($name);
             }
         );
     }

--- a/bundle/View/Redirect/ParameterProcessor.php
+++ b/bundle/View/Redirect/ParameterProcessor.php
@@ -12,20 +12,13 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 final class ParameterProcessor
 {
     /**
-     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
-     */
-    private $configResolver;
-
-    /**
      * @var \Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider
      */
     private $namedObjectProvider;
 
     public function __construct(
-        ConfigResolverInterface $configResolver,
         Provider $namedObjectProvider
     ) {
-        $this->configResolver = $configResolver;
         $this->namedObjectProvider = $namedObjectProvider;
     }
 
@@ -54,7 +47,6 @@ final class ParameterProcessor
             [
                 'location' => $view->getSiteLocation(),
                 'content' => $view->getSiteContent(),
-                'configResolver' => $this->configResolver,
                 'namedObject' => $this->namedObjectProvider,
             ]
         );
@@ -67,16 +59,6 @@ final class ParameterProcessor
      */
     private function registerFunctions(ExpressionLanguage $expressionLanguage): void
     {
-        $configResolver = $this->configResolver;
-
-        $expressionLanguage->register(
-            'config',
-            static function (): void {},
-            static function (array $arguments, string $name, ?string $namespace = null, ?string $scope = null) use ($configResolver) {
-                return $configResolver->getParameter($name, $namespace, $scope);
-            }
-        );
-
         $namedObjectProvider = $this->namedObjectProvider;
 
         $expressionLanguage->register(

--- a/bundle/View/Redirect/ParameterProcessor.php
+++ b/bundle/View/Redirect/ParameterProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect;
 
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider;
 use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;

--- a/bundle/View/Redirect/ParameterProcessor.php
+++ b/bundle/View/Redirect/ParameterProcessor.php
@@ -75,6 +75,14 @@ final class ParameterProcessor
                 return $namedObjectProvider->getLocation($name);
             }
         );
+
+        $expressionLanguage->register(
+            'namedTag',
+            static function (): void {},
+            static function (array $arguments, string $name) use ($namedObjectProvider) {
+                return $namedObjectProvider->getTag($name);
+            }
+        );
     }
 
 }

--- a/bundle/View/Redirect/ParameterProcessor.php
+++ b/bundle/View/Redirect/ParameterProcessor.php
@@ -33,7 +33,7 @@ final class ParameterProcessor
      */
     public function process($value, ContentView $view)
     {
-        if (!\is_string($value) || \strpos($value, '@=') !== 0) {
+        if (!\is_string($value) || \mb_stripos($value, '@=') !== 0) {
             return $value;
         }
 
@@ -82,5 +82,4 @@ final class ParameterProcessor
             }
         );
     }
-
 }

--- a/bundle/View/Redirect/RedirectConfiguration.php
+++ b/bundle/View/Redirect/RedirectConfiguration.php
@@ -42,7 +42,7 @@ final class RedirectConfiguration
         $this->absolute = $absolute;
     }
 
-    public static function fromConfigurationArray($config): RedirectConfiguration
+    public static function fromConfigurationArray(array $config): RedirectConfiguration
     {
         $target = $config['target'];
         $targetParameters = $config['target_parameters'];

--- a/bundle/View/Redirect/RedirectConfiguration.php
+++ b/bundle/View/Redirect/RedirectConfiguration.php
@@ -22,17 +22,24 @@ final class RedirectConfiguration
     private $permanent = false;
 
     /**
+     * @var bool
+     */
+    private $absolute = false;
+
+    /**
      * RedirectConfiguration constructor.
      *
      * @param string $target
      * @param array $targetParameters
      * @param bool $permanent
+     * @param bool $absolute
      */
-    public function __construct(string $target, array $targetParameters, bool $permanent)
+    public function __construct(string $target, array $targetParameters, bool $permanent, bool $absolute)
     {
         $this->target = $target;
         $this->targetParameters = $targetParameters;
         $this->permanent = $permanent;
+        $this->absolute = $absolute;
     }
 
     public static function fromConfigurationArray($config): RedirectConfiguration
@@ -40,8 +47,9 @@ final class RedirectConfiguration
         $target = $config['target'];
         $targetParameters = $config['target_parameters'];
         $permanent = $config['permanent'];
+        $absolute = $config['absolute'];
 
-        return new RedirectConfiguration($target, $targetParameters, $permanent);
+        return new RedirectConfiguration($target, $targetParameters, $permanent, $absolute);
     }
 
     /**
@@ -66,5 +74,13 @@ final class RedirectConfiguration
     public function isPermanent(): bool
     {
         return $this->permanent;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAbsolute(): bool
+    {
+        return $this->absolute;
     }
 }

--- a/bundle/View/Redirect/RedirectConfiguration.php
+++ b/bundle/View/Redirect/RedirectConfiguration.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect;
+
+final class RedirectConfiguration
+{
+    /**
+     * @var string
+     */
+    private $target;
+
+    /**
+     * @var array
+     */
+    private $targetParameters = [];
+
+    /**
+     * @var bool
+     */
+    private $permanent = false;
+
+    /**
+     * RedirectConfiguration constructor.
+     *
+     * @param string $target
+     * @param array $targetParameters
+     * @param bool $permanent
+     */
+    public function __construct(string $target, array $targetParameters, bool $permanent)
+    {
+        $this->target = $target;
+        $this->targetParameters = $targetParameters;
+        $this->permanent = $permanent;
+    }
+
+    public static function fromConfigurationArray($config): RedirectConfiguration
+    {
+        $target = $config['target'];
+        $targetParameters = $config['target_parameters'];
+        $permanent = $config['permanent'];
+
+        return new RedirectConfiguration($target, $targetParameters, $permanent);
+    }
+
+    /**
+     * @return string
+     */
+    public function getTarget(): string
+    {
+        return $this->target;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTargetParameters(): array
+    {
+        return $this->targetParameters;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPermanent(): bool
+    {
+        return $this->permanent;
+    }
+}

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect;
+
+use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
+use Netgen\EzPlatformSiteApi\API\Values\Content;
+use Netgen\EzPlatformSiteApi\API\Values\Location;
+use Symfony\Component\Routing\RouterInterface;
+
+final class Resolver
+{
+    /**
+     * @var \Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor
+     */
+    private $parameterProcessor;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    /**
+     * Resolver constructor.
+     *
+     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect\ParameterProcessor $parameterProcessor
+     * @param \Symfony\Component\Routing\RouterInterface $router
+     */
+    public function __construct(
+        ParameterProcessor $parameterProcessor,
+        RouterInterface $router
+    ) {
+        $this->parameterProcessor = $parameterProcessor;
+        $this->router = $router;
+    }
+
+    /**
+     * Builds a path to the redirect target.
+     *
+     * Value from configuration can be:
+     *      - SiteAPI location
+     *      - SiteAPI content
+     *      - location id fetched from config resolver
+     *
+     * @param string $redirectConfig
+     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView $view
+     *
+     * @return string
+     */
+    public function resolveTarget(string $redirectConfig, ContentView $view): string
+    {
+        $value = $this->parameterProcessor->process($redirectConfig, $view);
+
+        if (is_array($value)) {
+            if (count($value) < 1) {
+                return '/';
+            }
+
+            $value = reset($value);
+        }
+
+        if ($value instanceof Location || $value instanceof Content) {
+            return $this->router->generate($value);
+        }
+
+        if (is_int($value) || is_string($value)) {
+            return $this->router->generate(
+                'ez_urlalias',
+                [
+                    'locationId' => $value
+                ]
+            );
+        }
+
+        return '/';
+    }
+}

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -64,15 +64,6 @@ final class Resolver
             return $this->router->generate($value);
         }
 
-        if (is_int($value) || is_string($value)) {
-            return $this->router->generate(
-                'ez_urlalias',
-                [
-                    'locationId' => $value
-                ]
-            );
-        }
-
         return '/';
     }
 }

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -52,7 +52,7 @@ final class Resolver
         }
 
         if (\mb_stripos($redirectConfig->getTarget(), 'http') === 0) {
-            return $this->processUrl($redirectConfig);
+            return $redirectConfig->getTarget();
         }
 
         return $this->router->generate(
@@ -78,13 +78,5 @@ final class Resolver
         }
 
         return '/';
-    }
-
-    private function processUrl(RedirectConfiguration $redirectConfig): string
-    {
-        $url = $redirectConfig->getTarget();
-
-        return \count($redirectConfig->getTargetParameters()) > 0 ?
-            $url . '?' . \http_build_query($redirectConfig->getTargetParameters()) : $url;
     }
 }

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -46,11 +46,11 @@ final class Resolver
      */
     public function resolveTarget(RedirectConfiguration $redirectConfig, ContentView $view): string
     {
-        if (\strpos($redirectConfig->getTarget(), '@=') === 0) {
+        if (\mb_stripos($redirectConfig->getTarget(), '@=') === 0) {
             return $this->processExpression($redirectConfig, $view);
         }
 
-        if (\strpos($redirectConfig->getTarget(), 'http') === 0) {
+        if (\mb_stripos($redirectConfig->getTarget(), 'http') === 0) {
             return $this->processUrl($redirectConfig);
         }
 
@@ -83,9 +83,9 @@ final class Resolver
 
         $queryStringArray = [];
         foreach ($redirectConfig->getTargetParameters() as $key => $value) {
-            $queryStringArray[] = urlencode($key).'='.urlencode($value);
+            $queryStringArray[] = \urlencode($key) . '=' . \urlencode($value);
         }
 
-        return count($queryStringArray) > 0 ? $url.'?'.implode('&', $queryStringArray) : $url;
+        return \count($queryStringArray) > 0 ? $url . '?' . \implode('&', $queryStringArray) : $url;
     }
 }

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -38,30 +38,23 @@ final class Resolver
     /**
      * Builds a path to the redirect target.
      *
-     * Value from configuration can be:
-     *      - SiteAPI location
-     *      - SiteAPI content
-     *      - location id fetched from config resolver
-     *
-     * @param string $redirectConfig
+     * @param \Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect\RedirectConfiguration $redirectConfig
      * @param \Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView $view
      *
      * @return string
      */
-    public function resolveTarget(string $redirectConfig, ContentView $view): string
+    public function resolveTarget(RedirectConfiguration $redirectConfig, ContentView $view): string
     {
-        $value = $this->parameterProcessor->process($redirectConfig, $view);
-
-        if (is_array($value)) {
-            if (count($value) < 1) {
-                return '/';
-            }
-
-            $value = reset($value);
-        }
+        $value = $this->parameterProcessor->process(
+            $redirectConfig->getTarget(),
+            $view
+        );
 
         if ($value instanceof Location || $value instanceof Content) {
-            return $this->router->generate($value);
+            return $this->router->generate(
+                $value,
+                $redirectConfig->getTargetParameters()
+            );
         }
 
         return '/';

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -8,6 +8,7 @@ use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
 use Netgen\EzPlatformSiteApi\API\Values\Content;
 use Netgen\EzPlatformSiteApi\API\Values\Location;
 use Netgen\TagsBundle\API\Repository\Values\Tags\Tag;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 final class Resolver
@@ -56,7 +57,8 @@ final class Resolver
 
         return $this->router->generate(
             $redirectConfig->getTarget(),
-            $redirectConfig->getTargetParameters()
+            $redirectConfig->getTargetParameters(),
+            $redirectConfig->isAbsolute() ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH
         );
     }
 
@@ -70,7 +72,8 @@ final class Resolver
         if ($value instanceof Location || $value instanceof Content || $value instanceof Tag) {
             return $this->router->generate(
                 $value,
-                $redirectConfig->getTargetParameters()
+                $redirectConfig->getTargetParameters(),
+                $redirectConfig->isAbsolute() ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH
             );
         }
 

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -84,11 +84,7 @@ final class Resolver
     {
         $url = $redirectConfig->getTarget();
 
-        $queryStringArray = [];
-        foreach ($redirectConfig->getTargetParameters() as $key => $value) {
-            $queryStringArray[] = \urlencode($key) . '=' . \urlencode($value);
-        }
-
-        return \count($queryStringArray) > 0 ? $url . '?' . \implode('&', $queryStringArray) : $url;
+        return \count($redirectConfig->getTargetParameters()) > 0 ?
+            $url . '?' . \http_build_query($redirectConfig->getTargetParameters()) : $url;
     }
 }

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -45,6 +45,14 @@ final class Resolver
      */
     public function resolveTarget(RedirectConfiguration $redirectConfig, ContentView $view): string
     {
+        // simple string means it's a symfony route
+        if (\strpos($redirectConfig->getTarget(), '@=') !== 0) {
+            return $this->router->generate(
+                $redirectConfig->getTarget(),
+                $redirectConfig->getTargetParameters()
+            );
+        }
+
         $value = $this->parameterProcessor->process(
             $redirectConfig->getTarget(),
             $view

--- a/bundle/View/Redirect/Resolver.php
+++ b/bundle/View/Redirect/Resolver.php
@@ -7,6 +7,7 @@ namespace Netgen\Bundle\EzPlatformSiteApiBundle\View\Redirect;
 use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
 use Netgen\EzPlatformSiteApi\API\Values\Content;
 use Netgen\EzPlatformSiteApi\API\Values\Location;
+use Netgen\TagsBundle\API\Repository\Values\Tags\Tag;
 use Symfony\Component\Routing\RouterInterface;
 
 final class Resolver
@@ -58,7 +59,7 @@ final class Resolver
             $view
         );
 
-        if ($value instanceof Location || $value instanceof Content) {
+        if ($value instanceof Location || $value instanceof Content || $value instanceof Tag) {
             return $this->router->generate(
                 $value,
                 $redirectConfig->getTargetParameters()

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -113,8 +113,8 @@ Example configuration:
                             target: "@=namedObject.getLocation('homepage')"
                             target_parameters:
                                 foo: bar
+                                siteaccess: cro
                             permanent: true
-                            siteaccess: cro
                             absolute: true
                         match:
                             Identifier\ContentType: article

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -39,7 +39,7 @@ admin or intranet interface.
 Site API Content views
 ~~~~~~~~~~~~~~~~~~~~~~
 
-One you enable ``override_url_alias_view_action`` for a siteaccess, all your **full view** templates
+Once you enable ``override_url_alias_view_action`` for a siteaccess, all your **full view** templates
 and controllers will need to use Site API to keep working. They will be resolved from Site API view
 configuration, available under ``ngcontent_view`` key. That means Content and Location variables
 inside Twig templates will be instances of Site API Content and Location value objects, ``$view``
@@ -82,6 +82,96 @@ Rendering a line view for an article with ``ng_content:viewAction`` would use
 
 It is also possible to use custom controllers, this is documented on
 :doc:`Custom controllers reference</reference/custom_controllers>` documentation page.
+
+Redirections
+~~~~~~~~~~~~~
+
+With Site API, it's also possible to configure redirects directly from the view configuration.
+You can set up temporary or permanent redirect to either ``Content``, ``Location``, ``Tag``, Symfony route or any full url.
+
+For the target configuration you can use expression language, meaning it is easily possible to redirect, for example,
+to the parent of the current location, or to the named object.
+
+Example configuration:
+
+.. code-block:: yaml
+
+    ezpublish:
+        system:
+            frontend_group:
+                ngcontent_view:
+                    container:
+                        redirect:
+                            target: "@=location.parent"
+                            target_parameters:
+                                foo: bar
+                            permanent: false
+                        match:
+                            Identifier\ContentType: container
+                    article:
+                        redirect:
+                            target: "@=namedObject.getLocation('homepage')"
+                            target_parameters:
+                                foo: bar
+                            permanent: true
+                            siteaccess: cro
+                            absolute: true
+                        match:
+                            Identifier\ContentType: article
+                    category:
+                        redirect:
+                            target: '@=location.getChildren(1)[0]'
+                            permanent: true
+                        match:
+                            Identifier\ContentType: category
+                    news:
+                        redirect:
+                            target: 'login'
+                            target_parameters:
+                                foo: bar
+                            permanent: false
+                        match:
+                            Identifier\ContentType: news
+                    blog:
+                        redirect:
+                            target: 'https://netgen.io'
+                        match:
+                            Identifier\ContentType: blog
+
+There also shortcuts available for simplified configuration:
+
+.. code-block:: yaml
+
+    ezpublish:
+        system:
+            frontend_group:
+                ngcontent_view:
+                    container:
+                        temporary_redirect: "@=namedObject.getTag('running')"
+                        match:
+                            Identifier\ContentType: container
+                    category:
+                        permanent_redirect: "@=content.getFieldRelation('internal_redirect')"
+                        match:
+                            Identifier\ContentType: container
+
+.. note::
+
+    Configuration of named objects is documented in more detail below.
+
+Shortcut functions are available for accessing each type of named object directly:
+
+- ``namedContent(name)``
+
+    Provides access to named Content.
+
+- ``namedLocation(name)``
+
+    Provides access to named Location.
+
+- ``namedTag(name)``
+
+    Provides access to named Tag.
 
 .. _named_object_configuration:
 


### PR DESCRIPTION
New feature which enables us to configure redirects directly from the ngcontent_view configuration.

Example usages:
```
ezpublish:
    system:
        frontend_group:
            ngcontent_view:
                full:
                    ng_category:
                        temporary_redirect: "@=content.getFieldRelation('internal_redirect')"
                        match:
                            Identifier\ContentType: ng_category
                    ng_landing_page:
                        temporary_redirect: '@=location.getChildren(1)[0]'
                        match:
                            Identifier\ContentType: ng_landing_page
                  ng_container:
                        permanent_redirect: '@=location.parent'
                        match:
                            Identifier\ContentType: ng_container
                  some_content_type:
                        permanent_redirect: '@=namedObject.getLocation("homepage")'
                        match:
                            Identifier\ContentType: some_content_type
                    other_content_type:
                        redirect:
                            target: "@=namedObject.getTag('running')"
                            target_parameters:
                                foo: bar
                                siteaccess: cro
                            permanent: false
                            absolute: true
                        match:
                            Identifier\ContentType: other_content_type
                    news:
                        redirect:
                            target: 'login'
                            target_parameters:
                                foo: bar
                            permanent: true
                        match:
                            Identifier\ContentType: news
                    blog:
                        redirect:
                            target: 'https://netgen.io'
                        match:
                            Identifier\ContentType: blog
```