### PR TITLE
[3.3] Add Location::getFirstChild() method

### DIFF
--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -58,7 +58,7 @@ abstract class Location extends ValueObject
     /**
      * Return first child, limited by optional $contentTypeIdentifier.
      *
-     * @param string|null $contentTypeIdentifier
+     * @param null|string $contentTypeIdentifier
      *
      * @return null|\Netgen\EzPlatformSiteApi\API\Values\Location
      */

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -56,6 +56,15 @@ abstract class Location extends ValueObject
     abstract public function filterChildren(array $contentTypeIdentifiers = [], int $maxPerPage = 25, int $currentPage = 1): Pagerfanta;
 
     /**
+     * Return first child, limited by optional $contentTypeIdentifier.
+     *
+     * @param string|null $contentTypeIdentifier
+     *
+     * @return null|\Netgen\EzPlatformSiteApi\API\Values\Location
+     */
+    abstract public function getFirstChild(?string $contentTypeIdentifier = null): ?Location;
+
+    /**
      * Return an array of Location siblings, limited by optional $limit.
      *
      * @param int $limit

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -175,6 +175,23 @@ final class Location extends APILocation
         return $this->getFilterPager($criteria, $maxPerPage, $currentPage);
     }
 
+    public function getFirstChild(?string $contentTypeIdentifier = null): ?APILocation
+    {
+        $contentTypeIdentifiers = [];
+
+        if ($contentTypeIdentifier !== null) {
+            $contentTypeIdentifiers = [$contentTypeIdentifier];
+        }
+
+        $pager = $this->filterChildren($contentTypeIdentifiers, 1);
+
+        if ($pager->count() > 0) {
+            return $pager->getIterator()->current();
+        }
+
+        return null;
+    }
+
     public function getSiblings(int $limit = 25): array
     {
         return $this->filterSiblings([], $limit)->getIterator()->getArrayCopy();

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -341,6 +341,10 @@ abstract class BaseTest extends APIBaseTest
         $this->assertInstanceOf(Location::class, $children[0]);
         $this->assertEquals($data['childLocationId'], $children[0]->id);
 
+        $firstChild = $location->getFirstChild();
+        $this->assertInstanceOf(Location::class, $firstChild);
+        $this->assertEquals($data['childLocationId'], $firstChild->id);
+
         $siblings = $location->getSiblings();
         $this->assertIsArray($siblings);
         $this->assertCount(1, $siblings);


### PR DESCRIPTION
Lately I've seen some uses of getting the first child of a Location, implemented through the `getChildren()` method:

```twig
{{ location.children(1)[0].content.name }}
```

Method `getChildren()` returns an array of Location objects, intended for iteration, and using it like that is awkward and does not provide for limiting on the ContentType. For that reason I'm adding a new method on the Location object:

```php
Location::getFirstChild(?string $contentTypeIdentifier = null): ?Location
```

Use from Twig:

```twig
{% set firstChild = location.firstChild('article') %}

{% if firstChild is not null %}
    {{ firstChild.content.name }}
{% endif %}
```

Or in redirect configuration:

```yaml
ezpublish:
  system:
    frontend_group:
      ngcontent_view:
        full:
          ng_frontpage:
            temporary_redirect: '@=location.getFirstChild'
            match:
              Identifier\ContentType: ng_frontpage
```