### PR TITLE
[3.3] NGSTACK-363: Implement Content::getFirstNonEmptyField()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 [`3.2.2...master`](https://github.com/netgen/ezplatform-site-api/compare/3.2.2...master)
 
 * Add `Location::getFirstChild()` method ([#148](https://github.com/netgen/ezplatform-site-api/pull/148))
+* Add `Content::getFirstNonEmptyField()` method ([#150](https://github.com/netgen/ezplatform-site-api/pull/150))
 * Fix service ID for named object provider (https://github.com/netgen/ezplatform-site-api/commit/4ee25ebc26b801aececd55b198e7c1dad7ef2bce)
 
 3.2.2 (28.11.2019)

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -235,6 +235,8 @@ Accessing named objects
 - access from Twig is :ref:`documented on Templating page<named_object_template>`
 - access from Query Type configuration is :ref:`documented on Query Types page<named_object_query_types>`
 
+.. _content_field_inconsistencies:
+
 Content Field inconsistencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/reference/templating.rst
+++ b/docs/reference/templating.rst
@@ -204,11 +204,12 @@ Working with Content fields
 - **Choosing first existing and non-empty Field**
 
   You can choose first existing and non-empty Field from the multiple Field identifiers with
-  ``getFirstSetField()`` method on the Content object, also available as ``firstSetField`` in Twig:
+  ``getFirstNonEmptyField()`` method on the Content object, also available as ``getFirstNonEmptyField``
+  in Twig:
 
   .. code-block:: twig
 
-    {{ ng_render_field(content.firstSetField('title', 'short_title', 'name')) }}
+    {{ ng_render_field(content.getFirstNonEmptyField('title', 'short_title', 'name')) }}
 
   .. note::
 

--- a/docs/reference/templating.rst
+++ b/docs/reference/templating.rst
@@ -171,7 +171,8 @@ Working with Content fields
     Content's fields are lazy-loaded, which means they will be transparently loaded only at the
     point you access them.
 
-  The most convenient way to access a Content field in Twig is using the dot notation:
+  The most convenient way to access a Content field in Twig is from the ``fields`` property on the
+  Content object, using the dot notation:
 
   .. code-block:: twig
 
@@ -184,7 +185,7 @@ Working with Content fields
     {% set title_field = content.fields['title'] %}
 
   Or by calling ``getField()`` method on the Content object, also available as ``field()`` in Twig,
-  which requires Field identifier as argument:
+  which requires Field identifier as the argument:
 
   .. code-block:: twig
 
@@ -199,6 +200,31 @@ Working with Content fields
     {% if content.hasField('title') %}
         <p>Content has a 'title' field</p>
     {% endif %}
+
+- **Choosing first existing and non-empty Field**
+
+  You can choose first existing and non-empty Field from the multiple Field identifiers with
+  ``getFirstSetField()`` method on the Content object, also available as ``firstSetField`` in Twig:
+
+  .. code-block:: twig
+
+    {{ ng_render_field(content.firstSetField('title', 'short_title', 'name')) }}
+
+  .. note::
+
+    If no Fields are found on the Content object, a :ref:`surrogate type field<content_field_inconsistencies>`
+    will be returned. If all found Fields are empty, the first found Field will be returned.
+
+  .. note::
+
+    If returned Field can be of one of multiple FieldTypes (if identifiers for multiple FieldTypes
+    are given), accessing the value directly would be ambiguous. In that case it's best to use this
+    method together with ``ng_render_field`` Twig function, as is shown in the example above.
+
+  .. note::
+
+    At least one Field identifier must be given to this method, but any number of additional
+    identifiers can be provided.
 
 - **Displaying Field's metadata**
 

--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -78,7 +78,7 @@ abstract class Content extends ValueObject
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Field
      */
-    abstract public function getFirstSetField(string $firstIdentifier, string ...$otherIdentifiers): Field;
+    abstract public function getFirstNonEmptyField(string $firstIdentifier, string ...$otherIdentifiers): Field;
 
     /**
      * Returns a field value for the given field definition identifier.

--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -68,6 +68,19 @@ abstract class Content extends ValueObject
     abstract public function getFieldById($id): Field;
 
     /**
+     * Return the first existing and non-empty field.
+     *
+     * If no field is found in the Content, a surrogate field will be returned.
+     * If all found fields are empty, the first found field will be returned.
+     *
+     * @param string $firstIdentifier
+     * @param string ...$otherIdentifiers
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Field
+     */
+    abstract public function getFirstSetField(string $firstIdentifier, string ...$otherIdentifiers): Field;
+
+    /**
      * Returns a field value for the given field definition identifier.
      *
      * @param string $identifier

--- a/lib/API/Values/Fields.php
+++ b/lib/API/Values/Fields.php
@@ -62,5 +62,5 @@ abstract class Fields implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return \Netgen\EzPlatformSiteApi\API\Values\Field
      */
-    abstract public function getFirstSetField(string $firstIdentifier, string ...$otherIdentifiers): Field;
+    abstract public function getFirstNonEmptyField(string $firstIdentifier, string ...$otherIdentifiers): Field;
 }

--- a/lib/API/Values/Fields.php
+++ b/lib/API/Values/Fields.php
@@ -50,4 +50,17 @@ abstract class Fields implements IteratorAggregate, ArrayAccess, Countable
      * @return \Netgen\EzPlatformSiteApi\API\Values\Field
      */
     abstract public function getFieldById($id): Field;
+
+    /**
+     * Return first existing and non-empty field by the given $firstIdentifier and $identifiers.
+     *
+     * If no field is found in the Content, a surrogate field will be returned.
+     * If all found fields are empty, the first found field will be returned.
+     *
+     * @param string $firstIdentifier
+     * @param string ...$otherIdentifiers
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Field
+     */
+    abstract public function getFirstSetField(string $firstIdentifier, string ...$otherIdentifiers): Field;
 }

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -261,9 +261,9 @@ final class Content extends APIContent
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function getFirstSetField(string $firstIdentifier, string ...$otherIdentifiers): APIField
+    public function getFirstNonEmptyField(string $firstIdentifier, string ...$otherIdentifiers): APIField
     {
-        return $this->fields->getFirstSetField($firstIdentifier, ...$otherIdentifiers);
+        return $this->fields->getFirstNonEmptyField($firstIdentifier, ...$otherIdentifiers);
     }
 
     /**

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -261,6 +261,16 @@ final class Content extends APIContent
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
+    public function getFirstSetField(string $firstIdentifier, string ...$otherIdentifiers): APIField
+    {
+        return $this->fields->getFirstSetField($firstIdentifier, ...$otherIdentifiers);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
     public function getFieldValue(string $identifier): Value
     {
         return $this->getField($identifier)->value;

--- a/lib/Core/Site/Values/Fields.php
+++ b/lib/Core/Site/Values/Fields.php
@@ -237,6 +237,45 @@ final class Fields extends APIFields
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function getFirstSetField(string $firstIdentifier,  string ...$otherIdentifiers): APIField
+    {
+        $identifiers = \array_merge([$firstIdentifier], $otherIdentifiers);
+        $fields = $this->getAvailableFields($identifiers);
+
+        foreach ($fields as $field) {
+            if (!$field->isEmpty()) {
+                return $field;
+            }
+        }
+
+        return $fields[0] ?? $this->getSurrogateField($firstIdentifier, $this->content);
+    }
+
+    /**
+     * @param string[] $identifiers
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Field[]
+     */
+    private function getAvailableFields(array $identifiers): array
+    {
+        $fields = [];
+
+        foreach ($identifiers as $identifier) {
+            if ($this->hasField($identifier)) {
+                $fields[] = $this->getField($identifier);
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     private function initialize(): void

--- a/lib/Core/Site/Values/Fields.php
+++ b/lib/Core/Site/Values/Fields.php
@@ -237,11 +237,11 @@ final class Fields extends APIFields
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function getFirstSetField(string $firstIdentifier,  string ...$otherIdentifiers): APIField
+    public function getFirstSetField(string $firstIdentifier, string ...$otherIdentifiers): APIField
     {
         $identifiers = \array_merge([$firstIdentifier], $otherIdentifiers);
         $fields = $this->getAvailableFields($identifiers);

--- a/lib/Core/Site/Values/Fields.php
+++ b/lib/Core/Site/Values/Fields.php
@@ -241,7 +241,7 @@ final class Fields extends APIFields
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function getFirstSetField(string $firstIdentifier, string ...$otherIdentifiers): APIField
+    public function getFirstNonEmptyField(string $firstIdentifier, string ...$otherIdentifiers): APIField
     {
         $identifiers = \array_merge([$firstIdentifier], $otherIdentifiers);
         $fields = $this->getAvailableFields($identifiers);

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -238,7 +238,7 @@ abstract class BaseTest extends APIBaseTest
 
             $fieldById = $content->getFieldById($field->id);
             $fieldByIdentifier = $content->getField($identifier);
-            $fieldByFirstSetField = $content->getFirstSetField($identifier);
+            $fieldByFirstSetField = $content->getFirstNonEmptyField($identifier);
 
             $this->assertSame($field, $fieldById);
             $this->assertSame($field, $fieldByIdentifier);
@@ -263,7 +263,7 @@ abstract class BaseTest extends APIBaseTest
         $this->assertInstanceOf(Field::class, $content->getFieldById('non_existent_field'));
         $this->assertInstanceOf(SurrogateValue::class, $content->getFieldValue('non_existent_field'));
         $this->assertInstanceOf(SurrogateValue::class, $content->getFieldValueById('non_existent_field'));
-        $this->assertInstanceOf(SurrogateValue::class, $content->getFirstSetField('non_existent_field')->value);
+        $this->assertInstanceOf(SurrogateValue::class, $content->getFirstNonEmptyField('non_existent_field')->value);
     }
 
     protected function assertField(Content $content, string $identifier, string $languageCode, array $data): void

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -238,11 +238,11 @@ abstract class BaseTest extends APIBaseTest
 
             $fieldById = $content->getFieldById($field->id);
             $fieldByIdentifier = $content->getField($identifier);
-            $fieldByFirstSetField = $content->getFirstNonEmptyField($identifier);
+            $fieldByFirstNonEmptyField = $content->getFirstNonEmptyField($identifier);
 
             $this->assertSame($field, $fieldById);
             $this->assertSame($field, $fieldByIdentifier);
-            $this->assertSame($field, $fieldByFirstSetField);
+            $this->assertSame($field, $fieldByFirstNonEmptyField);
 
             $fieldValueById = $content->getFieldValueById($field->id);
             $fieldValueByIdentifier = $content->getFieldValue($identifier);

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -238,9 +238,11 @@ abstract class BaseTest extends APIBaseTest
 
             $fieldById = $content->getFieldById($field->id);
             $fieldByIdentifier = $content->getField($identifier);
+            $fieldByFirstSetField = $content->getFirstSetField($identifier);
 
             $this->assertSame($field, $fieldById);
-            $this->assertSame($fieldById, $fieldByIdentifier);
+            $this->assertSame($field, $fieldByIdentifier);
+            $this->assertSame($field, $fieldByFirstSetField);
 
             $fieldValueById = $content->getFieldValueById($field->id);
             $fieldValueByIdentifier = $content->getFieldValue($identifier);
@@ -261,6 +263,7 @@ abstract class BaseTest extends APIBaseTest
         $this->assertInstanceOf(Field::class, $content->getFieldById('non_existent_field'));
         $this->assertInstanceOf(SurrogateValue::class, $content->getFieldValue('non_existent_field'));
         $this->assertInstanceOf(SurrogateValue::class, $content->getFieldValueById('non_existent_field'));
+        $this->assertInstanceOf(SurrogateValue::class, $content->getFirstSetField('non_existent_field')->value);
     }
 
     protected function assertField(Content $content, string $identifier, string $languageCode, array $data): void

--- a/tests/lib/Unit/Core/Site/ContentFieldsMockTrait.php
+++ b/tests/lib/Unit/Core/Site/ContentFieldsMockTrait.php
@@ -188,7 +188,7 @@ trait ContentFieldsMockTrait
 
         $this->fieldTypeMock
             ->method('isEmptyValue')
-            ->willReturn(false);
+            ->willReturnCallback(static function ($field) {return empty($field->value);});
 
         return $this->fieldTypeMock;
     }

--- a/tests/lib/Unit/Core/Site/Values/FieldsTest.php
+++ b/tests/lib/Unit/Core/Site/Values/FieldsTest.php
@@ -291,6 +291,62 @@ final class FieldsTest extends TestCase
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
+    public function testFirstSetFieldReturnsFirstField(): void
+    {
+        $identifier = 'first';
+
+        $fields = $this->getFieldsUnderTest(false);
+
+        $field = $fields->getFirstSetField($identifier, 'second', 'third', 'fourth');
+
+        $this->assertEquals($identifier, $field->fieldDefIdentifier);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testFirstSetFieldReturnsFirstNonEmptyField(): void
+    {
+        $fields = $this->getFieldsUnderTest(false);
+
+        $field = $fields->getFirstSetField('1st', 'second', 'third', 'fourth');
+
+        $this->assertEquals('third', $field->fieldDefIdentifier);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testFirstSetFieldReturnsThirdField(): void
+    {
+        $identifier = 'third';
+
+        $fields = $this->getFieldsUnderTest(false);
+
+        $field = $fields->getFirstSetField('1st', '2nd', $identifier, 'fourth');
+
+        $this->assertEquals($identifier, $field->fieldDefIdentifier);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testFirstSetFieldReturnsSurrogateField(): void
+    {
+        $identifier = '1st';
+
+        $fields = $this->getFieldsUnderTest(false);
+
+        $field = $fields->getFirstSetField($identifier, '2nd', '3rd', '4th');
+
+        $this->assertEquals($identifier, $field->fieldDefIdentifier);
+        $this->assertEquals('ngsurrogate', $field->fieldTypeIdentifier);
+        $this->assertTrue($field->isEmpty());
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
     public function testDebugInfo(): void
     {
         $fields = $this->getFieldsUnderTest(true);
@@ -381,7 +437,7 @@ final class FieldsTest extends TestCase
             new RepoField([
                 'id' => 2,
                 'fieldDefIdentifier' => 'second',
-                'value' => new Value(2),
+                'value' => new Value(),
                 'languageCode' => 'eng-GB',
                 'fieldTypeIdentifier' => 'ezinteger',
             ]),

--- a/tests/lib/Unit/Core/Site/Values/FieldsTest.php
+++ b/tests/lib/Unit/Core/Site/Values/FieldsTest.php
@@ -297,7 +297,7 @@ final class FieldsTest extends TestCase
 
         $fields = $this->getFieldsUnderTest(false);
 
-        $field = $fields->getFirstSetField($identifier, 'second', 'third', 'fourth');
+        $field = $fields->getFirstNonEmptyField($identifier, 'second', 'third', 'fourth');
 
         $this->assertEquals($identifier, $field->fieldDefIdentifier);
     }
@@ -309,7 +309,7 @@ final class FieldsTest extends TestCase
     {
         $fields = $this->getFieldsUnderTest(false);
 
-        $field = $fields->getFirstSetField('1st', 'second', 'third', 'fourth');
+        $field = $fields->getFirstNonEmptyField('1st', 'second', 'third', 'fourth');
 
         $this->assertEquals('third', $field->fieldDefIdentifier);
     }
@@ -323,7 +323,7 @@ final class FieldsTest extends TestCase
 
         $fields = $this->getFieldsUnderTest(false);
 
-        $field = $fields->getFirstSetField('1st', '2nd', $identifier, 'fourth');
+        $field = $fields->getFirstNonEmptyField('1st', '2nd', $identifier, 'fourth');
 
         $this->assertEquals($identifier, $field->fieldDefIdentifier);
     }
@@ -337,7 +337,7 @@ final class FieldsTest extends TestCase
 
         $fields = $this->getFieldsUnderTest(false);
 
-        $field = $fields->getFirstSetField($identifier, '2nd', '3rd', '4th');
+        $field = $fields->getFirstNonEmptyField($identifier, '2nd', '3rd', '4th');
 
         $this->assertEquals($identifier, $field->fieldDefIdentifier);
         $this->assertEquals('ngsurrogate', $field->fieldTypeIdentifier);

--- a/tests/lib/Unit/Core/Site/Values/FieldsTest.php
+++ b/tests/lib/Unit/Core/Site/Values/FieldsTest.php
@@ -291,7 +291,7 @@ final class FieldsTest extends TestCase
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testFirstSetFieldReturnsFirstField(): void
+    public function testFirstNonEmptyFieldReturnsFirstField(): void
     {
         $identifier = 'first';
 
@@ -305,7 +305,7 @@ final class FieldsTest extends TestCase
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testFirstSetFieldReturnsFirstNonEmptyField(): void
+    public function testFirstNonEmptyFieldReturnsFirstNonEmptyField(): void
     {
         $fields = $this->getFieldsUnderTest(false);
 
@@ -317,7 +317,7 @@ final class FieldsTest extends TestCase
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testFirstSetFieldReturnsThirdField(): void
+    public function testFirstNonEmptyFieldReturnsThirdField(): void
     {
         $identifier = 'third';
 
@@ -331,7 +331,7 @@ final class FieldsTest extends TestCase
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testFirstSetFieldReturnsSurrogateField(): void
+    public function testFirstNonEmptyFieldReturnsSurrogateField(): void
     {
         $identifier = '1st';
 


### PR DESCRIPTION
This implements a new method on `Content` and `Field` objects:

```php
public function getFirstNonEmptyField(
    string $firstIdentifier, 
    string ...$otherIdentifiers
);
```

The method will return first existing and non-empty Field from the given Field identifiers.
If none of the fields are found or all found fields are empty, a `ngsurrogate` type field will be returned, which renders to an empty string.

In case this method is used in Twig to choose among Fields of multiple types, accessing the value directly would be ambiguous without first checking for the type of the returned Field. In that case it's best to use the method together with `ng_render_field`:

```twig
{{ ng_render_field(content.firstNonEmptyField('title', 'short_title', 'name')) }}
```