### PR TITLE
NGSTACK-377: variables in template identifier configuration

### DIFF
--- a/bundle/View/Provider/Configured.php
+++ b/bundle/View/Provider/Configured.php
@@ -126,7 +126,7 @@ class Configured implements ViewProvider
         $this->processRedirects($dto, $viewConfig, $view);
 
         if (isset($viewConfig['template'])) {
-            $dto->setTemplateIdentifier($viewConfig['template']);
+            $dto->setTemplateIdentifier($this->replaceTemplateIdentifierVariables($viewConfig['template'], $view));
         }
 
         if (isset($viewConfig['controller'])) {
@@ -138,6 +138,13 @@ class Configured implements ViewProvider
         }
 
         return $dto;
+    }
+
+    private function replaceTemplateIdentifierVariables(string $identifier, ContentView $view): string
+    {
+        $contentTypeIdentifier = $view->getSiteContent()->contentInfo->contentTypeIdentifier;
+
+        return \preg_replace('/{content_type}/', $contentTypeIdentifier, $identifier) ?? $identifier;
     }
 
     /**


### PR DESCRIPTION
This adds usage of variables in template identifier in the view configuration, making it significantly more readable. For example, it can reduce the following configuration:

```yaml
full:
    ng_feedback_form:
        template: "@ezdesign/content/full/ng_feedback_form.html.twig"
        controller: "netgen_information_collection.controller:displayAndHandle"
        match:
            Identifier\ContentType: ng_feedback_form
    ng_audio:
        template: "@ezdesign/content/full/ng_audio.html.twig"
        match:
            Identifier\ContentType: ng_audio
    ng_gallery:
        template: "@ezdesign/content/full/ng_gallery.html.twig"
        match:
            Identifier\ContentType: ng_gallery
    ng_video:
        template: "@ezdesign/content/full/ng_video.html.twig"
        match:
            Identifier\ContentType: ng_video
    ng_recipe:
        template: "@ezdesign/content/full/ng_recipe.html.twig"
        match:
            Identifier\ContentType: ng_recipe
    ng_topic:
        template: "@ezdesign/content/full/ng_topic.html.twig"
        match:
            Identifier\ContentType: ng_topic
    ng_htmlbox:
        template: "@ezdesign/content/full/ng_htmlbox.html.twig"
        match:
            Identifier\ContentType: ng_htmlbox
```

To this:

```yaml
full:
    ng_feedback_form:
        template: "@ezdesign/content/full/ng_feedback_form.html.twig"
        controller: netgen_information_collection.controller:displayAndHandle
        match:
            Identifier\ContentType: ng_feedback_form
    common:
        template: "@ezdesign/content/full/{content_type}.html.twig"
        match:
            Identifier\ContentType:
                - ng_audio
                - ng_gallery
                - ng_htmlbox
                - ng_recipe
                - ng_topic
                - ng_video
```

The drawback is that IDE won't be able to link to the template anymore, but I think this is still an improvement and the usage is optional anyway.