### PR TITLE
NGSTACK-413 Check if field relation value is empty

### DIFF
--- a/lib/Core/Site/Plugins/FieldType/RelationResolver/Resolver/Relation.php
+++ b/lib/Core/Site/Plugins/FieldType/RelationResolver/Resolver/Relation.php
@@ -22,6 +22,10 @@ class Relation extends Resolver
     protected function getRelationIdsFromValue(Value $value): array
     {
         /* @var \eZ\Publish\Core\FieldType\Relation\Value $value */
+        if (null === $value->destinationContentId) {
+            return [];
+        }
+
         return [$value->destinationContentId];
     }
 }


### PR DESCRIPTION
When fetching related content in Site API from single field relation, if there's no related content, it throws an error `Unsupported value (NULL)` because it creates a `ContentId` criterion with `null`. 