### PR TITLE
Enable autowired controllers

### DIFF
--- a/bundle/Controller/Controller.php
+++ b/bundle/Controller/Controller.php
@@ -100,4 +100,16 @@ abstract class Controller extends AbstractController
 
         return $namedObjectProvider;
     }
+
+    public static function getSubscribedServices()
+    {
+        return [
+            'netgen.ezplatform_site.site' => Site::class,
+            'netgen.ezplatform_site.named_object_provider' => Provider::class,
+            'ezpublish.query_type.registry' => QueryTypeRegistry::class,
+            'ezpublish.api.repository' => Repository::class,
+            'ezpublish.templating.global_helper' => GlobalHelper::class,
+            'ezpublish.config.resolver' => ConfigResolverInterface::class,
+        ] + parent::getSubscribedServices();
+    }
 }

--- a/bundle/Resources/config/services/autowiring.yml
+++ b/bundle/Resources/config/services/autowiring.yml
@@ -1,0 +1,4 @@
+services:
+    Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider: '@netgen.ezplatform_site.named_object_provider'
+    Netgen\EzPlatformSiteApi\API\Site: '@netgen.ezplatform_site.site'
+    eZ\Publish\Core\QueryType\QueryTypeRegistry: '@ezpublish.query_type.registry'


### PR DESCRIPTION
This PR allows controllers to be **autowired**, which means that explicit service definition for a controller is not required anymore. By default SiteAPI controller extends the **AbstractController** which implements **ServiceSubscriberInterface** with the set of necessary services. We need to expand **getSubscribedServices()** method with services that are necessary for the Site API controller.

The use case we want to achieve. Custom view controller without service definition:

```yaml
ng_recipe:
    template: "@ezdesign/content/full/ng_recipe.html.twig"
    controller: App\Controller\ExampleController::view
    match:
        Identifier\ContentType: ng_recipe
```

```php
<?php

namespace App\Controller;

use Netgen\Bundle\EzPlatformSiteApiBundle\Controller\Controller;
use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;

class ExampleController extends Controller
{
    public function view(ContentView $view)
    {
        $this->getConfigResolver();
        $this->getGlobalHelper();
        $this->getQueryTypeRegistry();
        $this->getRepository();

        $this->getNamedObjectProvider();
        $this->getSite();

        return $view;
    }
}
```

Without this code, calling **$this->getSite()** would result in this error:
```
Service "netgen.ezplatform_site.site" not found: even though it exists in the app's container, the container inside "App\Controller\ExampleController" is a smaller service locator that only knows about the "doctrine", "form.factory", "http_kernel", "parameter_bag", "request_stack", "router", "security.authorization_checker", "security.csrf.token_manager", "security.token_storage", "serializer", "session" and "twig" services. Try using dependency injection instead.
```