### PR TITLE
NGSTACK-411 Catch sort clause not implemented exception

### DIFF
--- a/lib/Core/Site/DomainObjectMapper.php
+++ b/lib/Core/Site/DomainObjectMapper.php
@@ -144,7 +144,8 @@ final class DomainObjectMapper
                 'innerVersionInfo' => $versionInfo,
                 'site' => $this->site,
                 'domainObjectMapper' => $this,
-            ]
+            ],
+            $this->logger
         );
     }
 

--- a/lib/Core/Site/QueryType/Location/Children.php
+++ b/lib/Core/Site/QueryType/Location/Children.php
@@ -11,6 +11,7 @@ use Netgen\EzPlatformSiteApi\API\Values\Location as SiteLocation;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Psr\Log\LoggerInterface;
 
 /**
  * Children Location QueryType.

--- a/lib/Core/Site/QueryType/Location/Children.php
+++ b/lib/Core/Site/QueryType/Location/Children.php
@@ -41,7 +41,7 @@ final class Children extends Location
             $location = $options['location'];
 
             try {
-                return $location->parent->innerLocation->getSortClauses();
+                return $location->innerLocation->getSortClauses();
             } catch (NotImplementedException $e) {
                 return [];
             }

--- a/lib/Core/Site/QueryType/Location/Children.php
+++ b/lib/Core/Site/QueryType/Location/Children.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location;
 
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
 use Netgen\EzPlatformSiteApi\API\Values\Location as SiteLocation;
@@ -39,7 +40,11 @@ final class Children extends Location
             /** @var \Netgen\EzPlatformSiteApi\API\Values\Location $location */
             $location = $options['location'];
 
-            return $location->innerLocation->getSortClauses();
+            try {
+                return $location->parent->innerLocation->getSortClauses();
+            } catch (NotImplementedException $e) {
+                return [];
+            }
         });
     }
 

--- a/lib/Core/Site/QueryType/Location/Children.php
+++ b/lib/Core/Site/QueryType/Location/Children.php
@@ -12,6 +12,7 @@ use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Children Location QueryType.
@@ -21,7 +22,7 @@ use Psr\Log\LoggerInterface;
 final class Children extends Location
 {
     /**
-     * @var \Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     protected $logger;
 
@@ -32,7 +33,7 @@ final class Children extends Location
      */
     public function __construct(?LoggerInterface $logger = null)
     {
-        $this->logger = $logger;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public static function getName(): string

--- a/lib/Core/Site/QueryType/Location/Children.php
+++ b/lib/Core/Site/QueryType/Location/Children.php
@@ -19,6 +19,21 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class Children extends Location
 {
+    /**
+     * @var \Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Children constructor.
+     *
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\LoggerInterface|null $logger
+     */
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
+
     public static function getName(): string
     {
         return 'SiteAPI:Location/Children';
@@ -43,6 +58,8 @@ final class Children extends Location
             try {
                 return $location->innerLocation->getSortClauses();
             } catch (NotImplementedException $e) {
+                $this->logger->notice("Cannot use sort clausses from parent location: {$e->getMessage()}");
+
                 return [];
             }
         });

--- a/lib/Core/Site/QueryType/Location/Siblings.php
+++ b/lib/Core/Site/QueryType/Location/Siblings.php
@@ -12,6 +12,7 @@ use Netgen\EzPlatformSiteApi\API\Values\Location as SiteLocation;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Psr\Log\LoggerInterface;
 
 /**
  * Siblings Location QueryType.

--- a/lib/Core/Site/QueryType/Location/Siblings.php
+++ b/lib/Core/Site/QueryType/Location/Siblings.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location;
 
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
@@ -42,7 +43,11 @@ final class Siblings extends Location
                 /** @var \Netgen\EzPlatformSiteApi\API\Values\Location $location */
                 $location = $options['location'];
 
-                return $location->parent->innerLocation->getSortClauses();
+                try {
+                    return $location->parent->innerLocation->getSortClauses();
+                } catch (NotImplementedException $e) {
+                    return [];
+                }
             }
         );
     }

--- a/lib/Core/Site/QueryType/Location/Siblings.php
+++ b/lib/Core/Site/QueryType/Location/Siblings.php
@@ -20,6 +20,21 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class Siblings extends Location
 {
+    /**
+     * @var \Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Children constructor.
+     *
+     * @param \Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\LoggerInterface|null $logger
+     */
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
+
     public static function getName(): string
     {
         return 'SiteAPI:Location/Siblings';
@@ -46,6 +61,8 @@ final class Siblings extends Location
                 try {
                     return $location->parent->innerLocation->getSortClauses();
                 } catch (NotImplementedException $e) {
+                    $this->logger->notice("Cannot use sort clausses from parent location: {$e->getMessage()}");
+
                     return [];
                 }
             }

--- a/lib/Core/Site/QueryType/Location/Siblings.php
+++ b/lib/Core/Site/QueryType/Location/Siblings.php
@@ -13,6 +13,7 @@ use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Siblings Location QueryType.
@@ -22,7 +23,7 @@ use Psr\Log\LoggerInterface;
 final class Siblings extends Location
 {
     /**
-     * @var \Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     protected $logger;
 
@@ -33,7 +34,7 @@ final class Siblings extends Location
      */
     public function __construct(?LoggerInterface $logger = null)
     {
-        $this->logger = $logger;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public static function getName(): string

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -16,6 +16,7 @@ use Netgen\EzPlatformSiteApi\API\Values\ContentInfo as APIContentInfo;
 use Netgen\EzPlatformSiteApi\API\Values\Location as APILocation;
 use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use Psr\Log\LoggerInterface;
 use Pagerfanta\Pagerfanta;
 
 final class Location extends APILocation

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -15,6 +15,7 @@ use Netgen\EzPlatformSiteApi\API\Values\Content as APIContent;
 use Netgen\EzPlatformSiteApi\API\Values\ContentInfo as APIContentInfo;
 use Netgen\EzPlatformSiteApi\API\Values\Location as APILocation;
 use Netgen\EzPlatformSiteApi\Core\Site\Pagination\Pagerfanta\FilterAdapter;
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use Pagerfanta\Pagerfanta;
 
 final class Location extends APILocation
@@ -216,11 +217,17 @@ final class Location extends APILocation
 
     private function getFilterPager(array $criteria, int $maxPerPage = 25, int $currentPage = 1): Pagerfanta
     {
+        try {
+            $sortClausses = $this->innerLocation->getSortClauses();
+        } catch (NotImplementedException $e) {
+            $sortClausses = [];
+        }
+
         $pager = new Pagerfanta(
             new FilterAdapter(
                 new LocationQuery([
                     'filter' => new LogicalAnd($criteria),
-                    'sortClauses' => $this->innerLocation->getSortClauses(),
+                    'sortClauses' => $sortClausses,
                 ]),
                 $this->site->getFilterService()
             )

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -60,12 +60,18 @@ final class Location extends APILocation
      */
     private $internalContent;
 
-    public function __construct(array $properties = [])
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(array $properties = [], LoggerInterface $logger)
     {
         $this->site = $properties['site'];
         $this->domainObjectMapper = $properties['domainObjectMapper'];
         $this->innerVersionInfo = $properties['innerVersionInfo'];
         $this->languageCode = $properties['languageCode'];
+        $this->logger = $logger;
 
         unset(
             $properties['site'],
@@ -220,6 +226,8 @@ final class Location extends APILocation
         try {
             $sortClausses = $this->innerLocation->getSortClauses();
         } catch (NotImplementedException $e) {
+            $this->logger->notice("Cannot use sort clausses from parent location: {$e->getMessage()}");
+
             $sortClausses = [];
         }
 

--- a/lib/Resources/config/query_types/base.yml
+++ b/lib/Resources/config/query_types/base.yml
@@ -23,12 +23,16 @@ services:
 
     netgen.ezplatform_site.query_type.location.children:
         class: Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\Children
+        arguments:
+            - '@logger'
         tags:
             - {name: ezpublish.query_type}
         public: false
 
     netgen.ezplatform_site.query_type.location.siblings:
         class: Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\Siblings
+        arguments:
+            - '@logger'
         tags:
             - {name: ezpublish.query_type}
         public: false

--- a/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
@@ -20,6 +20,7 @@ use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\Children;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\QueryType;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\Location;
 use Netgen\EzPlatformSiteApi\Tests\Unit\Core\Site\QueryType\QueryTypeBaseTest;
+use Psr\Log\NullLogger;
 
 /**
  * Location Children QueryType test case.
@@ -289,17 +290,20 @@ final class ChildrenTest extends QueryTypeBaseTest
 
     protected function getTestLocation(): Location
     {
-        return new Location([
-            'site' => false,
-            'domainObjectMapper' => false,
-            'innerVersionInfo' => false,
-            'languageCode' => false,
-            'innerLocation' => new RepositoryLocation([
-                'id' => 42,
-                'sortField' => RepositoryLocation::SORT_FIELD_PRIORITY,
-                'sortOrder' => RepositoryLocation::SORT_ORDER_DESC,
-            ]),
-        ]);
+        return new Location(
+            [
+                'site' => false,
+                'domainObjectMapper' => false,
+                'innerVersionInfo' => false,
+                'languageCode' => false,
+                'innerLocation' => new RepositoryLocation([
+                    'id' => 42,
+                    'sortField' => RepositoryLocation::SORT_FIELD_PRIORITY,
+                    'sortOrder' => RepositoryLocation::SORT_ORDER_DESC,
+                ]),
+            ],
+            new NullLogger()
+        );
     }
 
     protected function getSupportedParameters(): array

--- a/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/ChildrenTest.php
@@ -285,7 +285,7 @@ final class ChildrenTest extends QueryTypeBaseTest
 
     protected function getQueryTypeUnderTest(): QueryType
     {
-        return new Children();
+        return new Children(new NullLogger());
     }
 
     protected function getTestLocation(): Location

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
@@ -25,6 +25,7 @@ use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\Siblings;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\QueryType;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\Location;
 use Netgen\EzPlatformSiteApi\Tests\Unit\Core\Site\QueryType\QueryTypeBaseTest;
+use Psr\Log\NullLogger;
 
 /**
  * Location Siblings QueryType test case.
@@ -327,35 +328,41 @@ final class SiblingsTest extends QueryTypeBaseTest
             ->method('getLoadService')
             ->willReturn($loadServiceMock);
 
-        $parentLocation = new Location([
-            'site' => false,
-            'domainObjectMapper' => false,
-            'innerVersionInfo' => false,
-            'languageCode' => false,
-            'innerLocation' => new RepositoryLocation([
-                'id' => 42,
-                'sortField' => RepositoryLocation::SORT_FIELD_DEPTH,
-                'sortOrder' => RepositoryLocation::SORT_ORDER_ASC,
-            ]),
-        ]);
+        $parentLocation = new Location(
+            [
+                'site' => false,
+                'domainObjectMapper' => false,
+                'innerVersionInfo' => false,
+                'languageCode' => false,
+                'innerLocation' => new RepositoryLocation([
+                    'id' => 42,
+                    'sortField' => RepositoryLocation::SORT_FIELD_DEPTH,
+                    'sortOrder' => RepositoryLocation::SORT_ORDER_ASC,
+                ]),
+            ],
+            new NullLogger()
+        );
 
         $loadServiceMock
             ->method('loadLocation')
             ->with(42)
             ->willReturn($parentLocation);
 
-        return new Location([
-            'site' => $siteMock,
-            'domainObjectMapper' => false,
-            'innerVersionInfo' => false,
-            'languageCode' => false,
-            'innerLocation' => new RepositoryLocation([
-                'id' => 24,
-                'parentLocationId' => 42,
-                'sortField' => RepositoryLocation::SORT_FIELD_PRIORITY,
-                'sortOrder' => RepositoryLocation::SORT_ORDER_DESC,
-            ]),
-        ]);
+        return new Location(
+            [
+                'site' => $siteMock,
+                'domainObjectMapper' => false,
+                'innerVersionInfo' => false,
+                'languageCode' => false,
+                'innerLocation' => new RepositoryLocation([
+                    'id' => 24,
+                    'parentLocationId' => 42,
+                    'sortField' => RepositoryLocation::SORT_FIELD_PRIORITY,
+                    'sortOrder' => RepositoryLocation::SORT_ORDER_DESC,
+                ]),
+            ],
+            new NullLogger()
+        );
     }
 
     protected function getSupportedParameters(): array

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SiblingsTest.php
@@ -317,7 +317,7 @@ final class SiblingsTest extends QueryTypeBaseTest
 
     protected function getQueryTypeUnderTest(): QueryType
     {
-        return new Siblings();
+        return new Siblings(new NullLogger());
     }
 
     protected function getTestLocation(): Location

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
@@ -347,19 +347,22 @@ final class SubtreeTest extends QueryTypeBaseTest
 
     protected function getTestLocation(): Location
     {
-        return new Location([
-            'site' => false,
-            'domainObjectMapper' => false,
-            'innerVersionInfo' => false,
-            'languageCode' => false,
-            'innerLocation' => new RepositoryLocation([
-                'id' => 42,
-                'pathString' => '/3/5/7/11/',
-                'depth' => 4,
-                'sortField' => RepositoryLocation::SORT_FIELD_PRIORITY,
-                'sortOrder' => RepositoryLocation::SORT_ORDER_DESC,
-            ]),
-        ]);
+        return new Location(
+            [
+                'site' => false,
+                'domainObjectMapper' => false,
+                'innerVersionInfo' => false,
+                'languageCode' => false,
+                'innerLocation' => new RepositoryLocation([
+                    'id' => 42,
+                    'pathString' => '/3/5/7/11/',
+                    'depth' => 4,
+                    'sortField' => RepositoryLocation::SORT_FIELD_PRIORITY,
+                    'sortOrder' => RepositoryLocation::SORT_ORDER_DESC,
+                ]),
+            ],
+            new NullLogger()
+        );
     }
 
     protected function getSupportedParameters(): array

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
@@ -22,6 +22,7 @@ use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\Subtree;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\QueryType;
 use Netgen\EzPlatformSiteApi\Core\Site\Values\Location;
 use Netgen\EzPlatformSiteApi\Tests\Unit\Core\Site\QueryType\QueryTypeBaseTest;
+use Psr\Log\NullLogger;
 
 /**
  * Location Subtree QueryType test case.


### PR DESCRIPTION
Methods such as `filterChildren()` on Location internally use `getSortClausses()` method on parent location to determine sorting. If a sorting option, that is not implemented (eg. `Class name` in new stack), is selected in admin, it will throw an exception which is being propagated all the way up and it crashes the site.

This PR wraps the call for getting location's sort clauses into the try-catch block and uses empty array if sort clause is not implemented.

@pspanja Would it make sense to use some other default sort clause instead of empty array? Should I log this exception? 