### PR TITLE
NGSTACK-429: add methods to RelationService that work with the given Content version

### DIFF
--- a/docs/reference/services.rst
+++ b/docs/reference/services.rst
@@ -237,55 +237,6 @@ Methods
     :local:
 
 ``loadFieldRelation()``
-.......................
-
-Load single field relation from a specific field in a published version of a specific Content.
-
-The method will return ``null`` if the field does not contain relations that can be loaded by the
-current user. If the field contains multiple relations, the first one will be returned. The method
-supports optional filtering by ContentType.
-
-+----------------------------------------+------------------------------------------------------------------------------------+
-| **Parameters**                         | 1. ``string|int $contentId``                                                       |
-|                                        | 2. ``string $fieldDefinitionIdentifier``                                           |
-|                                        | 3. ``array $contentTypeIdentifiers = []``                                          |
-+----------------------------------------+------------------------------------------------------------------------------------+
-| **Returns**                            | :ref:`Content object<content_object>` or ``null``                                  |
-+----------------------------------------+------------------------------------------------------------------------------------+
-| **Example**                            | .. code-block:: php                                                                |
-|                                        |                                                                                    |
-|                                        |     $content = $relationService->loadFieldRelation(                                |
-|                                        |         42,                                                                        |
-|                                        |         'relations',                                                               |
-|                                        |         ['articles']                                                               |
-|                                        |     );                                                                             |
-|                                        |                                                                                    |
-+----------------------------------------+------------------------------------------------------------------------------------+
-
-``loadFieldRelations()``
-........................
-
-Load all field relations from a specific field in a published version of a specific Content. The
-method supports optional filtering by ContentType.
-
-+----------------------------------------+------------------------------------------------------------------------------------+
-| **Parameters**                         | 1. ``string|int $contentId``                                                       |
-|                                        | 2. ``string $fieldDefinitionIdentifier``                                           |
-|                                        | 3. ``array $contentTypeIdentifiers = []``                                          |
-+----------------------------------------+------------------------------------------------------------------------------------+
-| **Returns**                            | An array of :ref:`Content objects<content_object>`                                 |
-+----------------------------------------+------------------------------------------------------------------------------------+
-| **Example**                            | .. code-block:: php                                                                |
-|                                        |                                                                                    |
-|                                        |     $contentItems = $relationService->loadFieldRelations(                          |
-|                                        |         42,                                                                        |
-|                                        |         'relations',                                                               |
-|                                        |         ['articles']                                                               |
-|                                        |     );                                                                             |
-|                                        |                                                                                    |
-+----------------------------------------+------------------------------------------------------------------------------------+
-
-``getFieldRelation()``
 ......................
 
 Get single field relation from a specific field of a given Content.
@@ -311,7 +262,7 @@ supports optional filtering by ContentType.
 |                                        |                                                                                    |
 +----------------------------------------+------------------------------------------------------------------------------------+
 
-``getFieldRelations()``
+``loadFieldRelations()``
 .......................
 
 Get all field relations from a specific field of a given Content. The method supports optional

--- a/docs/reference/services.rst
+++ b/docs/reference/services.rst
@@ -239,7 +239,7 @@ Methods
 ``loadFieldRelation()``
 .......................
 
-Load single field relation from a specific field of a specific Content.
+Load single field relation from a specific field in a published version of a specific Content.
 
 The method will return ``null`` if the field does not contain relations that can be loaded by the
 current user. If the field contains multiple relations, the first one will be returned. The method
@@ -265,8 +265,8 @@ supports optional filtering by ContentType.
 ``loadFieldRelations()``
 ........................
 
-Load all field relations from a specific field of a specific Content. The method supports optional
-filtering by ContentType.
+Load all field relations from a specific field in a published version of a specific Content. The
+method supports optional filtering by ContentType.
 
 +----------------------------------------+------------------------------------------------------------------------------------+
 | **Parameters**                         | 1. ``string|int $contentId``                                                       |
@@ -277,8 +277,57 @@ filtering by ContentType.
 +----------------------------------------+------------------------------------------------------------------------------------+
 | **Example**                            | .. code-block:: php                                                                |
 |                                        |                                                                                    |
-|                                        |     $content = $relationService->loadFieldRelations(                               |
+|                                        |     $contentItems = $relationService->loadFieldRelations(                          |
 |                                        |         42,                                                                        |
+|                                        |         'relations',                                                               |
+|                                        |         ['articles']                                                               |
+|                                        |     );                                                                             |
+|                                        |                                                                                    |
++----------------------------------------+------------------------------------------------------------------------------------+
+
+``getFieldRelation()``
+......................
+
+Get single field relation from a specific field of a given Content.
+
+The method will return ``null`` if the field does not contain relations that can be loaded by the
+current user. If the field contains multiple relations, the first one will be returned. The method
+supports optional filtering by ContentType.
+
++----------------------------------------+------------------------------------------------------------------------------------+
+| **Parameters**                         | 1. ``Netgen\EzPlatformSiteApi\API\Values\Content $content``                        |
+|                                        | 2. ``string $fieldDefinitionIdentifier``                                           |
+|                                        | 3. ``array $contentTypeIdentifiers = []``                                          |
++----------------------------------------+------------------------------------------------------------------------------------+
+| **Returns**                            | :ref:`Content object<content_object>` or ``null``                                  |
++----------------------------------------+------------------------------------------------------------------------------------+
+| **Example**                            | .. code-block:: php                                                                |
+|                                        |                                                                                    |
+|                                        |     $content = $relationService->getFieldRelation(                                 |
+|                                        |         $content,                                                                  |
+|                                        |         'relations',                                                               |
+|                                        |         ['articles']                                                               |
+|                                        |     );                                                                             |
+|                                        |                                                                                    |
++----------------------------------------+------------------------------------------------------------------------------------+
+
+``getFieldRelations()``
+.......................
+
+Get all field relations from a specific field of a given Content. The method supports optional
+filtering by ContentType.
+
++----------------------------------------+------------------------------------------------------------------------------------+
+| **Parameters**                         | 1. ``Netgen\EzPlatformSiteApi\API\Values\Content $content``                        |
+|                                        | 2. ``string $fieldDefinitionIdentifier``                                           |
+|                                        | 3. ``array $contentTypeIdentifiers = []``                                          |
++----------------------------------------+------------------------------------------------------------------------------------+
+| **Returns**                            | An array of :ref:`Content objects<content_object>`                                 |
++----------------------------------------+------------------------------------------------------------------------------------+
+| **Example**                            | .. code-block:: php                                                                |
+|                                        |                                                                                    |
+|                                        |     $contentItems = $relationService->getFieldRelations(                           |
+|                                        |         $content,                                                                  |
 |                                        |         'relations',                                                               |
 |                                        |         ['articles']                                                               |
 |                                        |     );                                                                             |

--- a/lib/API/RelationService.php
+++ b/lib/API/RelationService.php
@@ -15,7 +15,7 @@ interface RelationService
      * Load single related Content from $fieldDefinitionIdentifier field in Content with given
      * $contentId, optionally limited by a list of $contentTypeIdentifiers.
      *
-     * @param int|string $contentId
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Content $content
      * @param string $fieldDefinitionIdentifier
      * @param array $contentTypeIdentifiers
      *
@@ -25,7 +25,7 @@ interface RelationService
      * @return null|\Netgen\EzPlatformSiteApi\API\Values\Content
      */
     public function loadFieldRelation(
-        $contentId,
+        $content,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = []
     ): ?Content;
@@ -34,7 +34,7 @@ interface RelationService
      * Load all related Content from $fieldDefinitionIdentifier field in Content with given
      * $contentId, optionally limited by a list of $contentTypeIdentifiers and $limit.
      *
-     * @param int|string $contentId
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Content $content
      * @param string $fieldDefinitionIdentifier
      * @param array $contentTypeIdentifiers
      * @param null|int $limit
@@ -45,41 +45,7 @@ interface RelationService
      * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
      */
     public function loadFieldRelations(
-        $contentId,
-        string $fieldDefinitionIdentifier,
-        array $contentTypeIdentifiers = [],
-        ?int $limit = null
-    ): array;
-
-    /**
-     * Get single related Content from $fieldDefinitionIdentifier field in $content,
-     * optionally limited by a list of $contentTypeIdentifiers.
-     *
-     * @param \Netgen\EzPlatformSiteApi\API\Values\Content $content
-     * @param string $fieldDefinitionIdentifier
-     * @param array $contentTypeIdentifiers
-     *
-     * @return null|\Netgen\EzPlatformSiteApi\API\Values\Content
-     */
-    public function getFieldRelation(
-        Content $content,
-        string $fieldDefinitionIdentifier,
-        array $contentTypeIdentifiers = []
-    ): ?Content;
-
-    /**
-     * Get all related Content from $fieldDefinitionIdentifier field in $content,
-     * optionally limited by a list of $contentTypeIdentifiers and $limit.
-     *
-     * @param \Netgen\EzPlatformSiteApi\API\Values\Content $content
-     * @param string $fieldDefinitionIdentifier
-     * @param array $contentTypeIdentifiers
-     * @param null|int $limit
-     *
-     * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
-     */
-    public function getFieldRelations(
-        Content $content,
+        $content,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = [],
         ?int $limit = null

--- a/lib/API/RelationService.php
+++ b/lib/API/RelationService.php
@@ -50,4 +50,38 @@ interface RelationService
         array $contentTypeIdentifiers = [],
         ?int $limit = null
     ): array;
+
+    /**
+     * Get single related Content from $fieldDefinitionIdentifier field in $content,
+     * optionally limited by a list of $contentTypeIdentifiers.
+     *
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Content $content
+     * @param string $fieldDefinitionIdentifier
+     * @param array $contentTypeIdentifiers
+     *
+     * @return null|\Netgen\EzPlatformSiteApi\API\Values\Content
+     */
+    public function getFieldRelation(
+        Content $content,
+        string $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = []
+    ): ?Content;
+
+    /**
+     * Get all related Content from $fieldDefinitionIdentifier field in $content,
+     * optionally limited by a list of $contentTypeIdentifiers and $limit.
+     *
+     * @param \Netgen\EzPlatformSiteApi\API\Values\Content $content
+     * @param string $fieldDefinitionIdentifier
+     * @param array $contentTypeIdentifiers
+     * @param null|int $limit
+     *
+     * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
+     */
+    public function getFieldRelations(
+        Content $content,
+        string $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = [],
+        ?int $limit = null
+    ): array;
 }

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -92,6 +92,50 @@ class RelationService implements RelationServiceInterface
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getFieldRelation(
+        Content $content,
+        string $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = []
+    ): ?Content {
+        $relatedContentItems = $this->getFieldRelations(
+            $content,
+            $fieldDefinitionIdentifier,
+            $contentTypeIdentifiers
+        );
+
+        return $relatedContentItems[0] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getFieldRelations(
+        Content $content,
+        string $fieldDefinitionIdentifier,
+        array $contentTypeIdentifiers = [],
+        ?int $limit = null
+    ): array {
+        $field = $content->getField($fieldDefinitionIdentifier);
+        $relationResolver = $this->relationResolverRegistry->get($field->fieldTypeIdentifier);
+
+        $relatedContentIds = $relationResolver->getRelationIds($field);
+        $relatedContentItems = $this->getRelatedContentItems(
+            $relatedContentIds,
+            $contentTypeIdentifiers,
+            $limit
+        );
+        $this->sortByIdOrder($relatedContentItems, $relatedContentIds);
+
+        return $relatedContentItems;
+    }
+
+    /**
      * Return an array of related Content items, optionally limited by $limit.
      *
      * @param array $relatedContentIds

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -51,57 +51,11 @@ class RelationService implements RelationServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function loadFieldRelation(
-        $contentId,
+        $content,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = []
     ): ?Content {
         $relatedContentItems = $this->loadFieldRelations(
-            $contentId,
-            $fieldDefinitionIdentifier,
-            $contentTypeIdentifiers
-        );
-
-        return $relatedContentItems[0] ?? null;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     */
-    public function loadFieldRelations(
-        $contentId,
-        string $fieldDefinitionIdentifier,
-        array $contentTypeIdentifiers = [],
-        ?int $limit = null
-    ): array {
-        $content = $this->site->getLoadService()->loadContent($contentId);
-
-        $field = $content->getField($fieldDefinitionIdentifier);
-        $relationResolver = $this->relationResolverRegistry->get($field->fieldTypeIdentifier);
-
-        $relatedContentIds = $relationResolver->getRelationIds($field);
-        $relatedContentItems = $this->getRelatedContentItems(
-            $relatedContentIds,
-            $contentTypeIdentifiers,
-            $limit
-        );
-        $this->sortByIdOrder($relatedContentItems, $relatedContentIds);
-
-        return $relatedContentItems;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     */
-    public function getFieldRelation(
-        Content $content,
-        string $fieldDefinitionIdentifier,
-        array $contentTypeIdentifiers = []
-    ): ?Content {
-        $relatedContentItems = $this->getFieldRelations(
             $content,
             $fieldDefinitionIdentifier,
             $contentTypeIdentifiers
@@ -115,12 +69,21 @@ class RelationService implements RelationServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
-    public function getFieldRelations(
-        Content $content,
+    public function loadFieldRelations(
+        $content,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = [],
         ?int $limit = null
     ): array {
+        if (!$content instanceof Content) {
+            @trigger_error(
+                'Using loadFieldRelations() with Content ID as the first argument is deprecated since version 3.5, and will be removed in 4.0. Provide Content instance instead.',
+                E_USER_DEPRECATED
+            );
+
+            $content = $this->site->getLoadService()->loadContent($content);
+        }
+
         $field = $content->getField($fieldDefinitionIdentifier);
         $relationResolver = $this->relationResolverRegistry->get($field->fieldTypeIdentifier);
 

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -319,16 +319,16 @@ final class Content extends APIContent
 
     public function getFieldRelation(string $fieldDefinitionIdentifier): ?APIContent
     {
-        return $this->site->getRelationService()->loadFieldRelation(
-            $this->id,
+        return $this->site->getRelationService()->getFieldRelation(
+            $this,
             $fieldDefinitionIdentifier
         );
     }
 
     public function getFieldRelations(string $fieldDefinitionIdentifier, int $limit = 25): array
     {
-        return $this->site->getRelationService()->loadFieldRelations(
-            $this->id,
+        return $this->site->getRelationService()->getFieldRelations(
+            $this,
             $fieldDefinitionIdentifier,
             [],
             $limit
@@ -341,8 +341,8 @@ final class Content extends APIContent
         int $maxPerPage = 25,
         int $currentPage = 1
     ): Pagerfanta {
-        $relations = $this->site->getRelationService()->loadFieldRelations(
-            $this->id,
+        $relations = $this->site->getRelationService()->getFieldRelations(
+            $this,
             $fieldDefinitionIdentifier,
             $contentTypeIdentifiers
         );

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -319,7 +319,7 @@ final class Content extends APIContent
 
     public function getFieldRelation(string $fieldDefinitionIdentifier): ?APIContent
     {
-        return $this->site->getRelationService()->getFieldRelation(
+        return $this->site->getRelationService()->loadFieldRelation(
             $this,
             $fieldDefinitionIdentifier
         );
@@ -327,7 +327,7 @@ final class Content extends APIContent
 
     public function getFieldRelations(string $fieldDefinitionIdentifier, int $limit = 25): array
     {
-        return $this->site->getRelationService()->getFieldRelations(
+        return $this->site->getRelationService()->loadFieldRelations(
             $this,
             $fieldDefinitionIdentifier,
             [],
@@ -341,7 +341,7 @@ final class Content extends APIContent
         int $maxPerPage = 25,
         int $currentPage = 1
     ): Pagerfanta {
-        $relations = $this->site->getRelationService()->getFieldRelations(
+        $relations = $this->site->getRelationService()->loadFieldRelations(
             $this,
             $fieldDefinitionIdentifier,
             $contentTypeIdentifiers

--- a/tests/lib/Integration/RelationServiceTest.php
+++ b/tests/lib/Integration/RelationServiceTest.php
@@ -165,14 +165,14 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testGetFieldRelation(): void
+    public function testLoadFieldRelationWithContent(): void
     {
         [$identifier, $testApiContent, $testRelationId] = $this->prepareTestContent();
 
         $relationService = $this->getSite()->getRelationService();
         $loadService = $this->getSite()->getLoadService();
         $testSiteContent = $loadService->loadContent($testApiContent->id);
-        $content = $relationService->getFieldRelation($testSiteContent, $identifier);
+        $content = $relationService->loadFieldRelation($testSiteContent, $identifier);
 
         $this->assertInstanceOf(Content::class, $content);
         $this->assertEquals($testRelationId, $content->id);
@@ -188,14 +188,14 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testGetFieldRelations(): void
+    public function testLoadFieldRelationsWithContent(): void
     {
         [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
 
         $relationService = $this->getSite()->getRelationService();
         $loadService = $this->getSite()->getLoadService();
         $testSiteContent = $loadService->loadContent($testApiContent->id);
-        $contentItems = $relationService->getFieldRelations($testSiteContent, $identifier);
+        $contentItems = $relationService->loadFieldRelations($testSiteContent, $identifier);
 
         $this->assertSameSize($testRelationIds, $contentItems);
 
@@ -216,14 +216,14 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testGetFieldRelationsWithTypeFilter(): void
+    public function testLoadFieldRelationsWithTypeFilterWithContent(): void
     {
         [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
 
         $relationService = $this->getSite()->getRelationService();
         $loadService = $this->getSite()->getLoadService();
         $testSiteContent = $loadService->loadContent($testApiContent->id);
-        $contentItems = $relationService->getFieldRelations($testSiteContent, $identifier, ['landing_page']);
+        $contentItems = $relationService->loadFieldRelations($testSiteContent, $identifier, ['landing_page']);
 
         $this->assertCount(1, $contentItems);
 
@@ -241,14 +241,14 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testGetFieldRelationsWithLimit(): void
+    public function testLoadFieldRelationsWithLimitWithContent(): void
     {
         [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
 
         $relationService = $this->getSite()->getRelationService();
         $loadService = $this->getSite()->getLoadService();
         $testSiteContent = $loadService->loadContent($testApiContent->id);
-        $contentItems = $relationService->getFieldRelations($testSiteContent, $identifier, [], 1);
+        $contentItems = $relationService->loadFieldRelations($testSiteContent, $identifier, [], 1);
 
         $this->assertCount(1, $contentItems);
 
@@ -266,14 +266,14 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testGetFieldRelationsWithTypeFilterAndLimit(): void
+    public function testLoadFieldRelationsWithTypeFilterAndLimitWithContent(): void
     {
         [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
 
         $relationService = $this->getSite()->getRelationService();
         $loadService = $this->getSite()->getLoadService();
         $testSiteContent = $loadService->loadContent($testApiContent->id);
-        $contentItems = $relationService->getFieldRelations($testSiteContent, $identifier, ['feedback_form'], 1);
+        $contentItems = $relationService->loadFieldRelations($testSiteContent, $identifier, ['feedback_form'], 1);
 
         $this->assertCount(1, $contentItems);
 
@@ -291,14 +291,14 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testGetFieldRelationsForNonexistentField(): void
+    public function testLoadFieldRelationsForNonexistentFieldWithContent(): void
     {
         [, , , $testApiContent] = $this->prepareTestContent();
 
         $relationService = $this->getSite()->getRelationService();
         $loadService = $this->getSite()->getLoadService();
         $testSiteContent = $loadService->loadContent($testApiContent->id);
-        $contentItems = $relationService->getFieldRelations($testSiteContent, 'nonexistent');
+        $contentItems = $relationService->loadFieldRelations($testSiteContent, 'nonexistent');
 
         $this->assertCount(0, $contentItems);
     }

--- a/tests/lib/Integration/RelationServiceTest.php
+++ b/tests/lib/Integration/RelationServiceTest.php
@@ -57,7 +57,7 @@ final class RelationServiceTest extends BaseTest
         $relationService = $this->getSite()->getRelationService();
         $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier);
 
-        $this->assertEquals(\count($testRelationIds), \count($contentItems));
+        $this->assertSameSize($testRelationIds, $contentItems);
 
         foreach ($testRelationIds as $index => $relationId) {
             $content = $contentItems[$index];
@@ -83,7 +83,7 @@ final class RelationServiceTest extends BaseTest
         $relationService = $this->getSite()->getRelationService();
         $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, ['landing_page']);
 
-        $this->assertEquals(1, \count($contentItems));
+        $this->assertCount(1, $contentItems);
 
         $this->assertInstanceOf(Content::class, $contentItems[0]);
         $this->assertEquals($testRelationIds[0], $contentItems[0]->id);
@@ -106,7 +106,7 @@ final class RelationServiceTest extends BaseTest
         $relationService = $this->getSite()->getRelationService();
         $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, [], 1);
 
-        $this->assertEquals(1, \count($contentItems));
+        $this->assertCount(1, $contentItems);
 
         $this->assertInstanceOf(Content::class, $contentItems[0]);
         $this->assertEquals($testRelationIds[0], $contentItems[0]->id);
@@ -129,7 +129,7 @@ final class RelationServiceTest extends BaseTest
         $relationService = $this->getSite()->getRelationService();
         $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, ['feedback_form'], 1);
 
-        $this->assertEquals(1, \count($contentItems));
+        $this->assertCount(1, $contentItems);
 
         $this->assertInstanceOf(Content::class, $contentItems[0]);
         $this->assertEquals($testRelationIds[1], $contentItems[0]->id);
@@ -151,6 +151,154 @@ final class RelationServiceTest extends BaseTest
 
         $relationService = $this->getSite()->getRelationService();
         $contentItems = $relationService->loadFieldRelations($testApiContent->id, 'nonexistent');
+
+        $this->assertCount(0, $contentItems);
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testGetFieldRelation(): void
+    {
+        [$identifier, $testApiContent, $testRelationId] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $loadService = $this->getSite()->getLoadService();
+        $testSiteContent = $loadService->loadContent($testApiContent->id);
+        $content = $relationService->getFieldRelation($testSiteContent, $identifier);
+
+        $this->assertInstanceOf(Content::class, $content);
+        $this->assertEquals($testRelationId, $content->id);
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testGetFieldRelations(): void
+    {
+        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $loadService = $this->getSite()->getLoadService();
+        $testSiteContent = $loadService->loadContent($testApiContent->id);
+        $contentItems = $relationService->getFieldRelations($testSiteContent, $identifier);
+
+        $this->assertSameSize($testRelationIds, $contentItems);
+
+        foreach ($testRelationIds as $index => $relationId) {
+            $content = $contentItems[$index];
+            $this->assertInstanceOf(Content::class, $content);
+            $this->assertEquals($relationId, $content->id);
+        }
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testGetFieldRelationsWithTypeFilter(): void
+    {
+        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $loadService = $this->getSite()->getLoadService();
+        $testSiteContent = $loadService->loadContent($testApiContent->id);
+        $contentItems = $relationService->getFieldRelations($testSiteContent, $identifier, ['landing_page']);
+
+        $this->assertCount(1, $contentItems);
+
+        $this->assertInstanceOf(Content::class, $contentItems[0]);
+        $this->assertEquals($testRelationIds[0], $contentItems[0]->id);
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testGetFieldRelationsWithLimit(): void
+    {
+        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $loadService = $this->getSite()->getLoadService();
+        $testSiteContent = $loadService->loadContent($testApiContent->id);
+        $contentItems = $relationService->getFieldRelations($testSiteContent, $identifier, [], 1);
+
+        $this->assertCount(1, $contentItems);
+
+        $this->assertInstanceOf(Content::class, $contentItems[0]);
+        $this->assertEquals($testRelationIds[0], $contentItems[0]->id);
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testGetFieldRelationsWithTypeFilterAndLimit(): void
+    {
+        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $loadService = $this->getSite()->getLoadService();
+        $testSiteContent = $loadService->loadContent($testApiContent->id);
+        $contentItems = $relationService->getFieldRelations($testSiteContent, $identifier, ['feedback_form'], 1);
+
+        $this->assertCount(1, $contentItems);
+
+        $this->assertInstanceOf(Content::class, $contentItems[0]);
+        $this->assertEquals($testRelationIds[1], $contentItems[0]->id);
+    }
+
+    /**
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testGetFieldRelationsForNonexistentField(): void
+    {
+        [, , , $testApiContent] = $this->prepareTestContent();
+
+        $relationService = $this->getSite()->getRelationService();
+        $loadService = $this->getSite()->getLoadService();
+        $testSiteContent = $loadService->loadContent($testApiContent->id);
+        $contentItems = $relationService->getFieldRelations($testSiteContent, 'nonexistent');
 
         $this->assertCount(0, $contentItems);
     }


### PR DESCRIPTION
This changes methods of the `RelationService`:

- `loadFieldRelation(Content $content, string $fieldDefinitionIdentifier, array $contentTypeIdentifiers = [])`
- `loadFieldRelations(Content $content, string $fieldDefinitionIdentifier, array $contentTypeIdentifiers = [])`

Using ID as the first argument still works, but is now deprecated.

The goal is to get relations of a given `Content` version, needed in the preview.