### PR TITLE
NGSTACK-423: preview shows published version instead of a draft

### DIFF
--- a/bundle/Controller/PreviewController.php
+++ b/bundle/Controller/PreviewController.php
@@ -10,7 +10,6 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController as BasePreviewController;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Netgen\Bundle\EzPlatformSiteApiBundle\Routing\UrlAliasRouter;
-use Netgen\EzPlatformSiteApi\API\Values\Location as SiteLocation;
 use Netgen\EzPlatformSiteApi\Core\Site\Site;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -116,7 +115,11 @@ class PreviewController extends BasePreviewController
             $content->versionInfo->versionNo,
             $languageCode
         );
-        $siteLocation = $this->getSiteLocation($content, $location, $languageCode);
+        $siteLocation = $this->site->getDomainObjectMapper()->mapLocation(
+            $location,
+            $content->versionInfo,
+            $languageCode
+        );
 
         $requestParams = $request->attributes->get('params');
         $requestParams['content'] = $siteContent;
@@ -125,30 +128,6 @@ class PreviewController extends BasePreviewController
         $request->attributes->set('content', $siteContent);
         $request->attributes->set('location', $siteLocation);
         $request->attributes->set('params', $requestParams);
-    }
-
-    /**
-     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
-     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
-     * @param string $languageCode
-     *
-     * @throws \Netgen\EzPlatformSiteApi\API\Exceptions\TranslationNotMatchedException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     *
-     * @return \Netgen\EzPlatformSiteApi\API\Values\Location
-     */
-    protected function getSiteLocation(Content $content, Location $location, string $languageCode): SiteLocation
-    {
-        if ($location->isDraft()) {
-            return $this->site->getDomainObjectMapper()->mapLocation(
-                $location,
-                $content->versionInfo,
-                $languageCode
-            );
-        }
-
-        return $this->site->getLoadService()->loadLocation($location->id);
     }
 
     /**

--- a/bundle/Resources/views/content_view_fallback/to_ez_platform/view.html.twig
+++ b/bundle/Resources/views/content_view_fallback/to_ez_platform/view.html.twig
@@ -5,7 +5,7 @@
 {% set layout = (viewType == 'full') %}
 
 {% if ezpublish.configResolver.getParameter('ng_fallback_without_subrequest') == true %}
-    {{ ng_ez_view_content(location.innerLocation|default(content.innerContent), viewType, [], layout) }}
+    {{ ng_ez_view_content(location|default(content), viewType, [], layout) }}
 {% else %}
     {{ render(
         controller(

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -118,6 +118,12 @@ through two configuration options (showing default values):
     where profiling is turned on. Depending on the number of views used on a page, performance
     improvement when not using subrequest can be significant.
 
+.. warning::
+
+    Because of reverse siteaccess matching limitations, when ``ng_fallback_without_subrequest`` is
+    turned off, links in the preview in the admin UI will not be correctly generated. To work around
+    that problem, turn the option on.
+
 .. note::
 
     For backward compatibility reasons, ``ng_fallback_to_secondary_content_view`` and


### PR DESCRIPTION
The problem was in the to eZ Platform view fallback template, which used Repository Content/Location. Since Repository Location lazy-loads it's Content and it has not information about the preview version, published version was displayed and rendered.

The fix simply passes Site Content/Location instead, which is already handled by the Twig extension. This should be sufficient as the function probably be used for full view only in automatic fallback.

Additionally the preview controller checked if the Location is draft, this seems unnecessary and is here removed for always mapping the Location from the existing data, including necessary `VersionInfo`.

One additional problem was found out while testing the preview, where when automatic fallback with subrequest is configured, links are not correctly generated for the selected siteaccess. This turned out to be a limitation of reverse siteaccess matching, where matcher in reversely matched siteaccess is not fully configured with all necessary data. This later propagates to fragment renderer through serialization and causes problems for a subrequest. Fixing this would have to involve fixing siteaccess matchers, which is out of our domain. A warning about this is added to the configuration docs.

FWIW, generating links works correctly without a subrequest, and this is already planned to be the default in v4.