### PR TITLE
Subrequestless view fallback is now enabled by default

### DIFF
--- a/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/bundle/Resources/config/ezplatform_default_settings.yml
@@ -37,8 +37,8 @@ parameters:
 
     # Default Site API settings under eZ Platform 'ezpublish/system' configuration node
     ezsettings.default.ng_site_api.site_api_is_primary_content_view: false
-    ezsettings.default.ng_site_api.fallback_to_secondary_content_view: false
-    ezsettings.default.ng_site_api.fallback_without_subrequest: false
+    ezsettings.default.ng_site_api.fallback_to_secondary_content_view: true
+    ezsettings.default.ng_site_api.fallback_without_subrequest: true
     ezsettings.default.ng_site_api.richtext_embed_without_subrequest: false
     ezsettings.default.ng_site_api.use_always_available_fallback: true
     ezsettings.default.ng_site_api.fail_on_missing_field: '%kernel.debug%'

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -118,8 +118,8 @@ through two configuration options (showing default values):
         system:
             frontend_group:
                 ng_site_api:
-                    fallback_to_secondary_content_view: false
-                    fallback_without_subrequest: false
+                    fallback_to_secondary_content_view: true
+                    fallback_without_subrequest: true
 
 - ``fallback_to_secondary_content_view``
 
@@ -141,12 +141,6 @@ through two configuration options (showing default values):
     Because of reverse siteaccess matching limitations, when ``ng_fallback_without_subrequest`` is
     turned off, links in the preview in the admin UI will not be correctly generated. To work around
     that problem, turn the option on.
-
-.. note::
-
-    For backward compatibility reasons, ``fallback_to_secondary_content_view`` and
-    ``fallback_without_subrequest`` are turned off, but in next major release that will be
-    reversed by default.
 
 .. note::
 


### PR DESCRIPTION
As was documented, view fallback without a subrequest is now enabled by default.