### PR TITLE
Remove deprecated loading Content relations by ID

### DIFF
--- a/lib/API/RelationService.php
+++ b/lib/API/RelationService.php
@@ -12,8 +12,8 @@ use Netgen\EzPlatformSiteApi\API\Values\Content;
 interface RelationService
 {
     /**
-     * Load single related Content from $fieldDefinitionIdentifier field in Content with given
-     * $contentId, optionally limited by a list of $contentTypeIdentifiers.
+     * Load single related Content from $fieldDefinitionIdentifier field in the given
+     * $content, optionally limited by a list of $contentTypeIdentifiers.
      *
      * @param \Netgen\EzPlatformSiteApi\API\Values\Content $content
      * @param string $fieldDefinitionIdentifier
@@ -25,14 +25,14 @@ interface RelationService
      * @return null|\Netgen\EzPlatformSiteApi\API\Values\Content
      */
     public function loadFieldRelation(
-        $content,
+        Content $content,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = []
     ): ?Content;
 
     /**
-     * Load all related Content from $fieldDefinitionIdentifier field in Content with given
-     * $contentId, optionally limited by a list of $contentTypeIdentifiers and $limit.
+     * Load all related Content from $fieldDefinitionIdentifier field in the given
+     * $content, optionally limited by a list of $contentTypeIdentifiers and $limit.
      *
      * @param \Netgen\EzPlatformSiteApi\API\Values\Content $content
      * @param string $fieldDefinitionIdentifier
@@ -45,7 +45,7 @@ interface RelationService
      * @return \Netgen\EzPlatformSiteApi\API\Values\Content[]
      */
     public function loadFieldRelations(
-        $content,
+        Content $content,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = [],
         ?int $limit = null

--- a/lib/Core/Site/RelationService.php
+++ b/lib/Core/Site/RelationService.php
@@ -51,7 +51,7 @@ class RelationService implements RelationServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function loadFieldRelation(
-        $content,
+        Content $content,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = []
     ): ?Content {
@@ -70,20 +70,11 @@ class RelationService implements RelationServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function loadFieldRelations(
-        $content,
+        Content $content,
         string $fieldDefinitionIdentifier,
         array $contentTypeIdentifiers = [],
         ?int $limit = null
     ): array {
-        if (!$content instanceof Content) {
-            @trigger_error(
-                'Using loadFieldRelations() with Content ID as the first argument is deprecated since version 3.5, and will be removed in 4.0. Provide Content instance instead.',
-                E_USER_DEPRECATED
-            );
-
-            $content = $this->site->getLoadService()->loadContent($content);
-        }
-
         $field = $content->getField($fieldDefinitionIdentifier);
         $relationResolver = $this->relationResolverRegistry->get($field->fieldTypeIdentifier);
 

--- a/tests/lib/Integration/RelationServiceTest.php
+++ b/tests/lib/Integration/RelationServiceTest.php
@@ -34,142 +34,6 @@ final class RelationServiceTest extends BaseTest
         [$identifier, $testApiContent, $testRelationId] = $this->prepareTestContent();
 
         $relationService = $this->getSite()->getRelationService();
-        $content = $relationService->loadFieldRelation($testApiContent->id, $identifier);
-
-        $this->assertInstanceOf(Content::class, $content);
-        $this->assertEquals($testRelationId, $content->id);
-    }
-
-    /**
-     * @throws \ErrorException
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function testLoadFieldRelations(): void
-    {
-        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
-
-        $relationService = $this->getSite()->getRelationService();
-        $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier);
-
-        $this->assertSameSize($testRelationIds, $contentItems);
-
-        foreach ($testRelationIds as $index => $relationId) {
-            $content = $contentItems[$index];
-            $this->assertInstanceOf(Content::class, $content);
-            $this->assertEquals($relationId, $content->id);
-        }
-    }
-
-    /**
-     * @throws \ErrorException
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function testLoadFieldRelationsWithTypeFilter(): void
-    {
-        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
-
-        $relationService = $this->getSite()->getRelationService();
-        $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, ['landing_page']);
-
-        $this->assertCount(1, $contentItems);
-
-        $this->assertInstanceOf(Content::class, $contentItems[0]);
-        $this->assertEquals($testRelationIds[0], $contentItems[0]->id);
-    }
-
-    /**
-     * @throws \ErrorException
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function testLoadFieldRelationsWithLimit(): void
-    {
-        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
-
-        $relationService = $this->getSite()->getRelationService();
-        $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, [], 1);
-
-        $this->assertCount(1, $contentItems);
-
-        $this->assertInstanceOf(Content::class, $contentItems[0]);
-        $this->assertEquals($testRelationIds[0], $contentItems[0]->id);
-    }
-
-    /**
-     * @throws \ErrorException
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function testLoadFieldRelationsWithTypeFilterAndLimit(): void
-    {
-        [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
-
-        $relationService = $this->getSite()->getRelationService();
-        $contentItems = $relationService->loadFieldRelations($testApiContent->id, $identifier, ['feedback_form'], 1);
-
-        $this->assertCount(1, $contentItems);
-
-        $this->assertInstanceOf(Content::class, $contentItems[0]);
-        $this->assertEquals($testRelationIds[1], $contentItems[0]->id);
-    }
-
-    /**
-     * @throws \ErrorException
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function testLoadFieldRelationsForNonexistentField(): void
-    {
-        [, , , $testApiContent] = $this->prepareTestContent();
-
-        $relationService = $this->getSite()->getRelationService();
-        $contentItems = $relationService->loadFieldRelations($testApiContent->id, 'nonexistent');
-
-        $this->assertCount(0, $contentItems);
-    }
-
-    /**
-     * @throws \ErrorException
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function testLoadFieldRelationWithContent(): void
-    {
-        [$identifier, $testApiContent, $testRelationId] = $this->prepareTestContent();
-
-        $relationService = $this->getSite()->getRelationService();
         $loadService = $this->getSite()->getLoadService();
         $testSiteContent = $loadService->loadContent($testApiContent->id);
         $content = $relationService->loadFieldRelation($testSiteContent, $identifier);
@@ -188,7 +52,7 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testLoadFieldRelationsWithContent(): void
+    public function testLoadFieldRelations(): void
     {
         [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
 
@@ -216,7 +80,7 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testLoadFieldRelationsWithTypeFilterWithContent(): void
+    public function testLoadFieldRelationsWithTypeFilter(): void
     {
         [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
 
@@ -241,7 +105,7 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testLoadFieldRelationsWithLimitWithContent(): void
+    public function testLoadFieldRelationsWithLimit(): void
     {
         [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
 
@@ -266,7 +130,7 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testLoadFieldRelationsWithTypeFilterAndLimitWithContent(): void
+    public function testLoadFieldRelationsWithTypeFilterAndLimit(): void
     {
         [$identifier, , , $testApiContent, $testRelationIds] = $this->prepareTestContent();
 
@@ -291,7 +155,7 @@ final class RelationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testLoadFieldRelationsForNonexistentFieldWithContent(): void
+    public function testLoadFieldRelationsForNonexistentField(): void
     {
         [, , , $testApiContent] = $this->prepareTestContent();
 


### PR DESCRIPTION
This removes support for loading Content relations by ID, deprecated in `3.5.0`.