### PR TITLE
Fix using $this pseudo variable inside a static function

### DIFF
--- a/lib/Core/Site/QueryType/Location/Children.php
+++ b/lib/Core/Site/QueryType/Location/Children.php
@@ -60,7 +60,7 @@ final class Children extends Location
             try {
                 return $location->innerLocation->getSortClauses();
             } catch (NotImplementedException $e) {
-                $this->logger->notice("Cannot use sort clausses from parent location: {$e->getMessage()}");
+                $this->logger->notice("Cannot use sort clauses from parent location: {$e->getMessage()}");
 
                 return [];
             }

--- a/lib/Core/Site/QueryType/Location/Children.php
+++ b/lib/Core/Site/QueryType/Location/Children.php
@@ -53,18 +53,21 @@ final class Children extends Location
         $resolver->setRequired('location');
         $resolver->setAllowedTypes('location', SiteLocation::class);
 
-        $resolver->setDefault('sort', static function (Options $options): array {
-            /** @var \Netgen\EzPlatformSiteApi\API\Values\Location $location */
-            $location = $options['location'];
+        $resolver->setDefault(
+            'sort',
+            function (Options $options): array {
+                /** @var \Netgen\EzPlatformSiteApi\API\Values\Location $location */
+                $location = $options['location'];
 
-            try {
-                return $location->innerLocation->getSortClauses();
-            } catch (NotImplementedException $e) {
-                $this->logger->notice("Cannot use sort clauses from parent location: {$e->getMessage()}");
+                try {
+                    return $location->innerLocation->getSortClauses();
+                } catch (NotImplementedException $e) {
+                    $this->logger->notice("Cannot use sort clauses from parent location: {$e->getMessage()}");
 
-                return [];
+                    return [];
+                }
             }
-        });
+        );
     }
 
     /**

--- a/lib/Core/Site/QueryType/Location/Siblings.php
+++ b/lib/Core/Site/QueryType/Location/Siblings.php
@@ -56,7 +56,7 @@ final class Siblings extends Location
 
         $resolver->setDefault(
             'sort',
-            static function (Options $options): array {
+            function (Options $options): array {
                 /** @var \Netgen\EzPlatformSiteApi\API\Values\Location $location */
                 $location = $options['location'];
 

--- a/lib/Core/Site/QueryType/Location/Siblings.php
+++ b/lib/Core/Site/QueryType/Location/Siblings.php
@@ -63,7 +63,7 @@ final class Siblings extends Location
                 try {
                     return $location->parent->innerLocation->getSortClauses();
                 } catch (NotImplementedException $e) {
-                    $this->logger->notice("Cannot use sort clausses from parent location: {$e->getMessage()}");
+                    $this->logger->notice("Cannot use sort clauses from parent location: {$e->getMessage()}");
 
                     return [];
                 }

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -225,18 +225,18 @@ final class Location extends APILocation
     private function getFilterPager(array $criteria, int $maxPerPage = 25, int $currentPage = 1): Pagerfanta
     {
         try {
-            $sortClausses = $this->innerLocation->getSortClauses();
+            $sortClauses = $this->innerLocation->getSortClauses();
         } catch (NotImplementedException $e) {
             $this->logger->notice("Cannot use sort clauses from parent location: {$e->getMessage()}");
 
-            $sortClausses = [];
+            $sortClauses = [];
         }
 
         $pager = new Pagerfanta(
             new FilterAdapter(
                 new LocationQuery([
                     'filter' => new LogicalAnd($criteria),
-                    'sortClauses' => $sortClausses,
+                    'sortClauses' => $sortClauses,
                 ]),
                 $this->site->getFilterService()
             )

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -227,7 +227,7 @@ final class Location extends APILocation
         try {
             $sortClausses = $this->innerLocation->getSortClauses();
         } catch (NotImplementedException $e) {
-            $this->logger->notice("Cannot use sort clausses from parent location: {$e->getMessage()}");
+            $this->logger->notice("Cannot use sort clauses from parent location: {$e->getMessage()}");
 
             $sortClausses = [];
         }


### PR DESCRIPTION
Fixed usage of `$this` pseudo variable inside static function in `Children` and `Siblings` query types.