### PR TITLE
NGSTACK-400: use expression function providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 eZ Platform Site API changelog
 ==============================
 
+4.1.0 Unreleased
+----------------
+
+[`4.0.1...4.1.0`](https://github.com/netgen/ezplatform-site-api/compare/4.0.1...4.1.0)
+
+### Added
+Enabled registering custom expression functions for Query Type configuration ([#182](https://github.com/netgen/ezplatform-site-api/pull/182))
+
 4.0.1 (20.09.2020)
 ------------------
 

--- a/bundle/DependencyInjection/Compiler/QueryTypeExpressionFunctionProviderPass.php
+++ b/bundle/DependencyInjection/Compiler/QueryTypeExpressionFunctionProviderPass.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use function array_keys;
+
+final class QueryTypeExpressionFunctionProviderPass implements CompilerPassInterface
+{
+    private const QueryTypeExpressionLanguageId = 'netgen.ezplatform_site.query_type.expression_language';
+    private const QueryTypeExpressionFunctionProviderTag = 'netgen.ezplatform_site.query_type.expression_function_provider';
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has(self::QueryTypeExpressionLanguageId)) {
+            return;
+        }
+
+        $expressionLanguageDefinition = $container->getDefinition(self::QueryTypeExpressionLanguageId);
+        $functionProviders = $container->findTaggedServiceIds(self::QueryTypeExpressionFunctionProviderTag);
+
+        foreach (array_keys($functionProviders) as $functionProviderId) {
+            $expressionLanguageDefinition->addMethodCall(
+                'registerProvider',
+                [$functionProviderId]
+            );
+        }
+    }
+}

--- a/bundle/NetgenEzPlatformSiteApiBundle.php
+++ b/bundle/NetgenEzPlatformSiteApiBundle.php
@@ -7,6 +7,7 @@ namespace Netgen\Bundle\EzPlatformSiteApiBundle;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\DefaultViewActionOverridePass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\InvalidRedirectConfigurationListenerPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\PreviewControllerOverridePass;
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\QueryTypeExpressionFunctionProviderPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\ViewBuilderRegistrationPass;
 use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Configuration\Parser\ContentView;
@@ -23,6 +24,7 @@ class NetgenEzPlatformSiteApiBundle extends Bundle
         $container->addCompilerPass(new DefaultViewActionOverridePass());
         $container->addCompilerPass(new InvalidRedirectConfigurationListenerPass());
         $container->addCompilerPass(new PreviewControllerOverridePass());
+        $container->addCompilerPass(new QueryTypeExpressionFunctionProviderPass());
         $container->addCompilerPass(new RelationResolverRegistrationPass());
         $container->addCompilerPass(new ViewBuilderRegistrationPass());
 

--- a/bundle/QueryType/ExpressionFunctionProvider.php
+++ b/bundle/QueryType/ExpressionFunctionProvider.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\QueryType;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use function in_array;
+use function strtotime;
+
+final class ExpressionFunctionProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction(
+                'viewParam',
+                static function (): void {},
+                static function (array $arguments, string $name, $default) {
+                    /** @var \Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView $view */
+                    $view = $arguments['view'];
+
+                    if ($view->hasParameter($name)) {
+                        return $view->getParameter($name);
+                    }
+
+                    return $default;
+                }
+            ),
+            new ExpressionFunction(
+                'queryParam',
+                static function (): void {},
+                static function (array $arguments, string $name, $default, ?array $allowed = null) {
+                    /** @var \Symfony\Component\HttpFoundation\Request $request */
+                    $request = $arguments['request'];
+
+                    if (!$request->query->has($name)) {
+                        return $default;
+                    }
+
+                    $value = $request->query->get($name);
+
+                    if ($allowed === null || in_array($value, $allowed, true)) {
+                        return $value;
+                    }
+
+                    return $default;
+                }
+            ),
+            new ExpressionFunction(
+                'queryParamString',
+                static function (): void {},
+                static function (array $arguments, string $name, string $default, ?array $allowed = null): string {
+                    /** @var \Symfony\Component\HttpFoundation\Request $request */
+                    $request = $arguments['request'];
+
+                    if (!$request->query->has($name)) {
+                        return $default;
+                    }
+
+                    $value = (string) $request->query->get($name);
+
+                    if ($allowed === null || in_array($value, $allowed, true)) {
+                        return $value;
+                    }
+
+                    return $default;
+                }
+            ),
+            new ExpressionFunction(
+                'queryParamInt',
+                static function (): void {},
+                static function (array $arguments, string $name, int $default, ?array $allowed = null): int {
+                    /** @var \Symfony\Component\HttpFoundation\Request $request */
+                    $request = $arguments['request'];
+
+                    if (!$request->query->has($name)) {
+                        return $default;
+                    }
+
+                    $value = $request->query->getInt($name);
+
+                    if ($allowed === null || in_array($value, $allowed, true)) {
+                        return $value;
+                    }
+
+                    return $default;
+                }
+            ),
+            new ExpressionFunction(
+                'queryParamFloat',
+                static function (): void {},
+                static function (array $arguments, string $name, float $default, ?array $allowed = null): float {
+                    /** @var \Symfony\Component\HttpFoundation\Request $request */
+                    $request = $arguments['request'];
+
+                    if (!$request->query->has($name)) {
+                        return $default;
+                    }
+
+                    $value = (float) $request->query->get($name);
+
+                    if ($allowed === null || in_array($value, $allowed, true)) {
+                        return $value;
+                    }
+
+                    return $default;
+                }
+            ),
+            new ExpressionFunction(
+                'queryParamBool',
+                static function (): void {},
+                static function (array $arguments, string $name, bool $default, ?array $allowed = null): bool {
+                    /** @var \Symfony\Component\HttpFoundation\Request $request */
+                    $request = $arguments['request'];
+
+                    if (!$request->query->has($name)) {
+                        return $default;
+                    }
+
+                    $value = $request->query->getBoolean($name);
+
+                    if ($allowed === null || in_array($value, $allowed, true)) {
+                        return $value;
+                    }
+
+                    return $default;
+                }
+            ),
+            new ExpressionFunction(
+                'timestamp',
+                static function (): void {},
+                static function (array $arguments, string $timeString) {
+                    return strtotime($timeString);
+                }
+            ),
+            new ExpressionFunction(
+                'config',
+                static function (): void {},
+                static function (array $arguments, string $name, ?string $namespace = null, ?string $scope = null) {
+                    /** @var \Symfony\Component\HttpFoundation\Request $request */
+                    $configResolver = $arguments['configResolver'];
+
+                    return $configResolver->getParameter($name, $namespace, $scope);
+                }
+            ),
+            new ExpressionFunction(
+                'namedContent',
+                static function (): void {},
+                static function (array $arguments, string $name) {
+                    /** @var \Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider $namedObjectProvider */
+                    $namedObjectProvider = $arguments['namedObject'];
+
+                    return $namedObjectProvider->getContent($name);
+                }
+            ),
+            new ExpressionFunction(
+                'namedLocation',
+                static function (): void {},
+                static function (array $arguments, string $name) {
+                    /** @var \Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider $namedObjectProvider */
+                    $namedObjectProvider = $arguments['namedObject'];
+
+                    return $namedObjectProvider->getLocation($name);
+                }
+            ),
+            new ExpressionFunction(
+                'namedTag',
+                static function (): void {},
+                static function (array $arguments, string $name) {
+                    /** @var \Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider $namedObjectProvider */
+                    $namedObjectProvider = $arguments['namedObject'];
+
+                    return $namedObjectProvider->getTag($name);
+                }
+            ),
+        ];
+    }
+}

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -9,11 +9,10 @@ use Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider;
 use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\RequestStack;
-use function in_array;
 use function is_string;
+use function mb_strlen;
 use function mb_strpos;
 use function mb_substr;
-use function strtotime;
 
 /**
  * ParameterProcessor processes query configuration parameter values using ExpressionLanguage.
@@ -22,6 +21,16 @@ use function strtotime;
  */
 final class ParameterProcessor
 {
+    /**
+     * @var string
+     */
+    private const ExpressionMarker = '@=';
+
+    /**
+     * @var \Symfony\Component\ExpressionLanguage\ExpressionLanguage
+     */
+    private $expressionLanguage;
+
     /**
      * @var \Symfony\Component\HttpFoundation\RequestStack
      */
@@ -38,10 +47,12 @@ final class ParameterProcessor
     private $namedObjectProvider;
 
     public function __construct(
+        ExpressionLanguage $expressionLanguage,
         RequestStack $requestStack,
         ConfigResolverInterface $configResolver,
         Provider $namedObjectProvider
     ) {
+        $this->expressionLanguage = $expressionLanguage;
         $this->requestStack = $requestStack;
         $this->configResolver = $configResolver;
         $this->namedObjectProvider = $namedObjectProvider;
@@ -53,19 +64,17 @@ final class ParameterProcessor
      * Parameter $view is used to provide values for evaluation.
      *
      * @param mixed $value
+     *
+     * @return mixed
      */
     public function process($value, ContentView $view)
     {
-        if (!is_string($value) || mb_strpos($value, '@=') !== 0) {
+        if (!$this->isExpression($value)) {
             return $value;
         }
 
-        $language = new ExpressionLanguage();
-
-        $this->registerFunctions($language);
-
-        return $language->evaluate(
-            mb_substr($value, 2),
+        return $this->expressionLanguage->evaluate(
+            $this->extractExpression($value),
             [
                 'view' => $view,
                 'location' => $view->getSiteLocation(),
@@ -77,169 +86,13 @@ final class ParameterProcessor
         );
     }
 
-    /**
-     * Register functions with the given $expressionLanguage.
-     */
-    private function registerFunctions(ExpressionLanguage $expressionLanguage): void
+    private function isExpression($value): bool
     {
-        $expressionLanguage->register(
-            'viewParam',
-            static function (): void {},
-            static function (array $arguments, string $name, $default) {
-                /** @var \Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView $view */
-                $view = $arguments['view'];
+        return is_string($value) && mb_strpos($value, self::ExpressionMarker) === 0;
+    }
 
-                if ($view->hasParameter($name)) {
-                    return $view->getParameter($name);
-                }
-
-                return $default;
-            }
-        );
-
-        $expressionLanguage->register(
-            'queryParam',
-            static function (): void {},
-            static function (array $arguments, string $name, $default, ?array $allowed = null) {
-                /** @var \Symfony\Component\HttpFoundation\Request $request */
-                $request = $arguments['request'];
-
-                if (!$request->query->has($name)) {
-                    return $default;
-                }
-
-                $value = $request->query->get($name);
-
-                if ($allowed === null || in_array($value, $allowed, true)) {
-                    return $value;
-                }
-
-                return $default;
-            }
-        );
-
-        $expressionLanguage->register(
-            'queryParamString',
-            static function (): void {},
-            static function (array $arguments, string $name, string $default, ?array $allowed = null): string {
-                /** @var \Symfony\Component\HttpFoundation\Request $request */
-                $request = $arguments['request'];
-
-                if (!$request->query->has($name)) {
-                    return $default;
-                }
-
-                $value = (string) $request->query->get($name);
-
-                if ($allowed === null || in_array($value, $allowed, true)) {
-                    return $value;
-                }
-
-                return $default;
-            }
-        );
-
-        $expressionLanguage->register(
-            'queryParamInt',
-            static function (): void {},
-            static function (array $arguments, string $name, int $default, ?array $allowed = null): int {
-                /** @var \Symfony\Component\HttpFoundation\Request $request */
-                $request = $arguments['request'];
-
-                if (!$request->query->has($name)) {
-                    return $default;
-                }
-
-                $value = $request->query->getInt($name);
-
-                if ($allowed === null || in_array($value, $allowed, true)) {
-                    return $value;
-                }
-
-                return $default;
-            }
-        );
-
-        $expressionLanguage->register(
-            'queryParamFloat',
-            static function (): void {},
-            static function (array $arguments, string $name, float $default, ?array $allowed = null): float {
-                /** @var \Symfony\Component\HttpFoundation\Request $request */
-                $request = $arguments['request'];
-
-                if (!$request->query->has($name)) {
-                    return $default;
-                }
-
-                $value = (float) $request->query->get($name);
-
-                if ($allowed === null || in_array($value, $allowed, true)) {
-                    return $value;
-                }
-
-                return $default;
-            }
-        );
-
-        $expressionLanguage->register(
-            'queryParamBool',
-            static function (): void {},
-            static function (array $arguments, string $name, bool $default, ?array $allowed = null): bool {
-                /** @var \Symfony\Component\HttpFoundation\Request $request */
-                $request = $arguments['request'];
-
-                if (!$request->query->has($name)) {
-                    return $default;
-                }
-
-                $value = $request->query->getBoolean($name);
-
-                if ($allowed === null || in_array($value, $allowed, true)) {
-                    return $value;
-                }
-
-                return $default;
-            }
-        );
-
-        $expressionLanguage->register(
-            'timestamp',
-            static function (): void {},
-            static function (array $arguments, string $timeString) {
-                return strtotime($timeString);
-            }
-        );
-
-        $expressionLanguage->register(
-            'config',
-            static function (): void {},
-            function (array $arguments, string $name, ?string $namespace = null, ?string $scope = null) {
-                return $this->configResolver->getParameter($name, $namespace, $scope);
-            }
-        );
-
-        $expressionLanguage->register(
-            'namedContent',
-            static function (): void {},
-            function (array $arguments, string $name) {
-                return $this->namedObjectProvider->getContent($name);
-            }
-        );
-
-        $expressionLanguage->register(
-            'namedLocation',
-            static function (): void {},
-            function (array $arguments, string $name) {
-                return $this->namedObjectProvider->getLocation($name);
-            }
-        );
-
-        $expressionLanguage->register(
-            'namedTag',
-            static function (): void {},
-            function (array $arguments, string $name) {
-                return $this->namedObjectProvider->getTag($name);
-            }
-        );
+    private function extractExpression(string $value): string
+    {
+        return mb_substr($value, mb_strlen(self::ExpressionMarker));
     }
 }

--- a/bundle/Resources/config/services/query_type.yml
+++ b/bundle/Resources/config/services/query_type.yml
@@ -1,7 +1,19 @@
 services:
+    # Expression language function providers tagged with
+    # 'netgen.ezplatform_site.query_type.expression_function_provider'
+    # are registered to this service
+    netgen.ezplatform_site.query_type.expression_language:
+        class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
+
+    netgen.ezplatform_site.query_type.expression_function_provider:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ExpressionFunctionProvider
+        tags:
+            - { name: netgen.ezplatform_site.query_type.expression_function_provider }
+
     netgen.ezplatform_site.query_type.parameter_processor:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor
         arguments:
+            - '@netgen.ezplatform_site.query_type.expression_language'
             - '@request_stack'
             - '@ezpublish.config.resolver'
             - '@netgen.ezplatform_site.named_object_provider'

--- a/docs/reference/query_types.rst
+++ b/docs/reference/query_types.rst
@@ -413,6 +413,22 @@ Miscellaneous
         Function ``timestamp()`` maps directly to the PHP's function `strtotime <https://secure.php.net/manual/en/function.strtotime.php>`_.
         That means it accepts any date and time format `supported by that function <https://secure.php.net/manual/en/datetime.formats.php>`_.
 
+Extending expressions
+~~~~~~~~~~~~~~~~~~~~~
+
+You can add you own functions for parameter expression through an expression function provider,
+implementing ``Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface`` interface
+and tagging it with ``netgen.ezplatform_site.query_type.expression_function_provider`` service tag.
+
+Values that will be provided for evaluation in your custom expression function implementation are:
+
+- ``view``, Site API View object
+- ``location``, :ref:`Site API Location object<location_object>`
+- ``content``, :ref:`Site API Content object<content_object>`
+- ``request``, Symfony's Request object (current request)
+- ``configResolver``, eZ Platform ConfigResolver service
+- ``namedObject``, :ref:`Site API NamedObjectProvider service<named_object_php>`
+
 Templating
 --------------------------------------------------------------------------------
 

--- a/tests/bundle/DependencyInjection/Compiler/QueryTypeExpressionFunctionProviderPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/QueryTypeExpressionFunctionProviderPassTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Netgen\Bundle\EzPlatformSiteApiBundle\DependencyInjection\Compiler\QueryTypeExpressionFunctionProviderPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @internal
+ */
+final class QueryTypeExpressionFunctionProviderPassTest extends AbstractCompilerPassTestCase
+{
+    protected const QueryTypeExpressionLanguageId = 'netgen.ezplatform_site.query_type.expression_language';
+    protected const QueryTypeExpressionFunctionProviderTag = 'netgen.ezplatform_site.query_type.expression_function_provider';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setDefinition(
+            self::QueryTypeExpressionLanguageId,
+            new Definition()
+        );
+    }
+
+    public function testRegisterProvider(): void
+    {
+        $serviceId = 'expression_function_provider_service_id';
+        $definition = new Definition();
+        $definition->addTag(self::QueryTypeExpressionFunctionProviderTag);
+        $this->setDefinition($serviceId, $definition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            self::QueryTypeExpressionLanguageId,
+            'registerProvider',
+            [$serviceId]
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new QueryTypeExpressionFunctionProviderPass());
+    }
+}

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Tests\QueryType;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\ExpressionLanguage\ExpressionLanguage;
 use Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider;
+use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ExpressionFunctionProvider;
 use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor;
 use Netgen\Bundle\EzPlatformSiteApiBundle\View\ContentView;
 use Netgen\EzPlatformSiteApi\API\Values\Content;
@@ -286,8 +288,9 @@ final class ParameterProcessorTest extends TestCase
 
         $configResolver = $this->getConfigResolverMock();
         $namedObjectProvider = $this->getNamedObjectProviderMock();
+        $expressionLanguage = new ExpressionLanguage(null, [new ExpressionFunctionProvider()]);
 
-        return new ParameterProcessor($requestStack, $configResolver, $namedObjectProvider);
+        return new ParameterProcessor($expressionLanguage, $requestStack, $configResolver, $namedObjectProvider);
     }
 
     /**

--- a/tests/bundle/QueryType/QueryDefinitionMapperTest.php
+++ b/tests/bundle/QueryType/QueryDefinitionMapperTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Tests\QueryType;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\ExpressionLanguage\ExpressionLanguage;
 use eZ\Publish\Core\QueryType\QueryType;
 use eZ\Publish\Core\QueryType\QueryTypeRegistry;
 use InvalidArgumentException;
 use Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider;
+use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ExpressionFunctionProvider;
 use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor;
 use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinition;
 use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\QueryDefinitionMapper;
@@ -184,13 +186,11 @@ final class QueryDefinitionMapperTest extends TestCase
 
     protected function getQueryDefinitionMapperUnderTest(): QueryDefinitionMapper
     {
-        $queryDefinitionMapper = new QueryDefinitionMapper(
+        return new QueryDefinitionMapper(
             $this->getQueryTypeRegistryMock(),
             $this->getParameterProcessor(),
             $this->getConfigResolverMock()
         );
-
-        return $queryDefinitionMapper;
     }
 
     /**
@@ -275,8 +275,9 @@ final class QueryDefinitionMapperTest extends TestCase
         $configResolverMock = $this->getMockBuilder(ConfigResolverInterface::class)->getMock();
         /** @var \Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider $namedObjectProviderMock */
         $namedObjectProviderMock = $this->getMockBuilder(Provider::class)->getMock();
+        $expressionLanguage = new ExpressionLanguage(null, [new ExpressionFunctionProvider()]);
 
-        return new ParameterProcessor($requestStack, $configResolverMock, $namedObjectProviderMock);
+        return new ParameterProcessor($expressionLanguage, $requestStack, $configResolverMock, $namedObjectProviderMock);
     }
 
     /**


### PR DESCRIPTION
This adds usage of expression function providers to register functions to the language expression used in Query Types.

The implementation uses a service tag and compiler pass to register the provider, thus enabling registration of custom providers.