### PR TITLE
NGSTACK-441: redefine default eZ full view template

### DIFF
--- a/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/bundle/Resources/config/ezplatform_default_settings.yml
@@ -14,6 +14,11 @@ parameters:
     # By default we don't override URL alias view action, for that reason this is commented out
     #ezsettings.default.pagelayout: '@@NetgenEzPlatformSiteApi/pagelayout.html.twig'
 
+    # We override the default full view template because of the automatic view fallback, to prevent
+    # the default one from extending configured page_layout, which is customized for Site API
+    # See: @EzPublishCore/default/content/full.html.twig
+    ezplatform.default_view_templates.content.full: '@@NetgenEzPlatformSiteApi/ez_default/content/full.html.twig'
+
     ezsettings.default.ng_fieldtypes.ezrichtext.embed.content:
         template: "@@NetgenEzPlatformSiteApi/default/field_type/ezrichtext/embed/content.html.twig"
     ezsettings.default.ng_fieldtypes.ezrichtext.embed.content_denied:

--- a/bundle/Resources/views/ez_default/content/full.html.twig
+++ b/bundle/Resources/views/ez_default/content/full.html.twig
@@ -1,0 +1,8 @@
+{% extends no_layout == true ? view_base_layout : '@EzPublishCore/pagelayout.html.twig' %}
+{% block content %}
+    <h2>{{ ez_content_name(content) }}</h2>
+    {% for field in content.fieldsByLanguage(language|default(null)) %}
+        <h3>{{ field.fieldDefIdentifier }}</h3>
+        {{ ez_render_field(content, field.fieldDefIdentifier) }}
+    {% endfor %}
+{% endblock %}


### PR DESCRIPTION
The problem is with the automatic view fallback, where the default eZ full view template tries to extend our customized pagelayout, which is specific for Site API. This redefines the default eZ full view template so that it always extends `@EzPublishCore/pagelayout.html.twig`.