### PR TITLE
NGSTACK-442: implement internal Content view route config

### DIFF
--- a/bundle/DependencyInjection/Configuration/Parser/SiteApi.php
+++ b/bundle/DependencyInjection/Configuration/Parser/SiteApi.php
@@ -43,6 +43,12 @@ class SiteApi extends AbstractParser
             ->booleanNode('render_missing_field_info')
                 ->info('Controls rendering useful debug information in place of a missing field')
             ->end()
+            ->booleanNode('enable_internal_view_route')
+                ->info('Controls whether internal Content view route will work (applies for a frontend siteaccess only)')
+            ->end()
+            ->booleanNode('redirect_internal_view_route_to_url_alias')
+                ->info('Controls whether internal Content view route will redirect to URL alias route')
+            ->end()
         ->end();
 
         NamedObjectBuilder::build($childrenBuilder);
@@ -60,6 +66,8 @@ class SiteApi extends AbstractParser
             'show_hidden_items',
             'fail_on_missing_field',
             'render_missing_field_info',
+            'enable_internal_view_route',
+            'redirect_internal_view_route_to_url_alias',
         ];
 
         foreach ($booleanKeys as $parameterName) {

--- a/bundle/EventListener/InternalContentViewRouteListener.php
+++ b/bundle/EventListener/InternalContentViewRouteListener.php
@@ -83,7 +83,9 @@ class InternalContentViewRouteListener implements EventSubscriberInterface
         }
 
         if (!$this->configResolver->getParameter('ng_site_api.enable_internal_view_route')) {
-            throw new NotFoundHttpException();
+            throw new NotFoundHttpException(
+                'Internal Content view route has been disabled, check your Site API configuration for: "ng_site_api.enable_internal_view_route"'
+            );
         }
 
         $event->setResponse($this->getResponse($request));
@@ -155,7 +157,7 @@ class InternalContentViewRouteListener implements EventSubscriberInterface
         try {
             return $this->router->generate(UrlAliasRouter::URL_ALIAS_ROUTE_NAME, $parameters);
         } catch (Exception $e) {
-            throw new NotFoundHttpException();
+            throw new NotFoundHttpException('URL alias could not be generated');
         }
     }
 }

--- a/bundle/EventListener/InternalContentViewRouteListener.php
+++ b/bundle/EventListener/InternalContentViewRouteListener.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\EzPlatformSiteApiBundle\EventListener;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
+use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use EzSystems\EzPlatformAdminUiBundle\EzPlatformAdminUiBundle;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
+use function class_exists;
+use function in_array;
+
+class InternalContentViewRouteListener implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var \Symfony\Component\HttpKernel\Fragment\FragmentHandler
+     */
+    private $fragmentHandler;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var array
+     */
+    private $siteaccessGroups;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver,
+        FragmentHandler $fragmentHandler,
+        RouterInterface $router,
+        array $siteaccessGroups
+    ) {
+        $this->configResolver = $configResolver;
+        $this->fragmentHandler = $fragmentHandler;
+        $this->router = $router;
+        $this->siteaccessGroups = $siteaccessGroups;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 0],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$this->isInternalContentViewRoute($request)) {
+            return;
+        }
+
+        $siteaccess = $request->attributes->get('siteaccess');
+
+        if (!$siteaccess instanceof SiteAccess || $this->isAdminSiteaccess($siteaccess)) {
+            return;
+        }
+
+        if (!$this->configResolver->getParameter('ng_site_api.enable_internal_view_route')) {
+            throw new NotFoundHttpException();
+        }
+
+        if ($this->configResolver->getParameter('ng_site_api.redirect_internal_view_route_to_url_alias')) {
+            $response = new RedirectResponse($this->generateUrlAlias($request));
+        } else {
+            $response = new Response($this->renderView($request));
+        }
+
+        $event->setResponse($response);
+    }
+
+    private function renderView(Request $request): string
+    {
+        $attributes = [
+            'contentId' => $request->attributes->getInt('contentId'),
+            'layout' => $request->attributes->getBoolean('layout', true),
+            'viewType' => 'full',
+        ];
+
+        $locationId = $request->attributes->get('locationId');
+
+        if ($locationId !== null) {
+            $attributes['locationId'] = (int) $locationId;
+        }
+
+        return $this->fragmentHandler->render(
+            new ControllerReference('ng_content:viewAction', $attributes)
+        );
+    }
+
+    private function isInternalContentViewRoute(Request $request): bool
+    {
+        return $request->attributes->get('_route') === UrlAliasGenerator::INTERNAL_CONTENT_VIEW_ROUTE;
+    }
+
+    private function isAdminSiteaccess(SiteAccess $siteaccess) : bool
+    {
+        return in_array(
+            $siteaccess->name,
+            $this->siteaccessGroups[$this->getAdminSiteaccessGroupName()] ?? [],
+            true
+        );
+    }
+
+    private function getAdminSiteaccessGroupName(): string
+    {
+        if (class_exists(EzPlatformAdminUiBundle::class)) {
+            return EzPlatformAdminUiBundle::ADMIN_GROUP_NAME;
+        }
+
+        return 'admin_group';
+    }
+
+    private function generateUrlAlias(Request $request): string
+    {
+        $parameters = [
+            'contentId' => $request->attributes->getInt('contentId'),
+        ];
+
+        $locationId = $request->attributes->get('locationId');
+
+        if ($locationId !== null) {
+            $parameters['locationId'] = (int) $locationId;
+        }
+
+        return $this->router->generate(UrlAliasRouter::URL_ALIAS_ROUTE_NAME, $parameters);
+    }
+}

--- a/bundle/EventListener/InternalContentViewRouteListener.php
+++ b/bundle/EventListener/InternalContentViewRouteListener.php
@@ -98,7 +98,7 @@ class InternalContentViewRouteListener implements EventSubscriberInterface
         return new Response($this->renderView($request));
     }
 
-    private function renderView(Request $request): string
+    private function renderView(Request $request): ?string
     {
         $attributes = [
             'contentId' => $request->attributes->getInt('contentId'),

--- a/bundle/EventListener/InternalContentViewRouteListener.php
+++ b/bundle/EventListener/InternalContentViewRouteListener.php
@@ -85,13 +85,16 @@ class InternalContentViewRouteListener implements EventSubscriberInterface
             throw new NotFoundHttpException();
         }
 
+        $event->setResponse($this->getResponse($request));
+    }
+
+    private function getResponse(Request $request): Response
+    {
         if ($this->configResolver->getParameter('ng_site_api.redirect_internal_view_route_to_url_alias')) {
-            $response = new RedirectResponse($this->generateUrlAlias($request));
-        } else {
-            $response = new Response($this->renderView($request));
+            return new RedirectResponse($this->generateUrlAlias($request));
         }
 
-        $event->setResponse($response);
+        return new Response($this->renderView($request));
     }
 
     private function renderView(Request $request): string

--- a/bundle/EventListener/InternalContentViewRouteListener.php
+++ b/bundle/EventListener/InternalContentViewRouteListener.php
@@ -113,7 +113,7 @@ class InternalContentViewRouteListener implements EventSubscriberInterface
         }
 
         return $this->fragmentHandler->render(
-            new ControllerReference('ng_content:viewAction', $attributes)
+            new ControllerReference('ng_content::viewAction', $attributes)
         );
     }
 

--- a/bundle/EventListener/InternalContentViewRouteListener.php
+++ b/bundle/EventListener/InternalContentViewRouteListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\EventListener;
 
+use Exception;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
@@ -91,7 +92,7 @@ class InternalContentViewRouteListener implements EventSubscriberInterface
     private function getResponse(Request $request): Response
     {
         if ($this->configResolver->getParameter('ng_site_api.redirect_internal_view_route_to_url_alias')) {
-            return new RedirectResponse($this->generateUrlAlias($request));
+            return new RedirectResponse($this->generateUrlAlias($request), 308);
         }
 
         return new Response($this->renderView($request));
@@ -151,6 +152,10 @@ class InternalContentViewRouteListener implements EventSubscriberInterface
             $parameters['locationId'] = (int) $locationId;
         }
 
-        return $this->router->generate(UrlAliasRouter::URL_ALIAS_ROUTE_NAME, $parameters);
+        try {
+            return $this->router->generate(UrlAliasRouter::URL_ALIAS_ROUTE_NAME, $parameters);
+        } catch (Exception $e) {
+            throw new NotFoundHttpException();
+        }
     }
 }

--- a/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/bundle/Resources/config/ezplatform_default_settings.yml
@@ -49,6 +49,8 @@ parameters:
     ezsettings.default.ng_site_api.show_hidden_items: false
     ezsettings.default.ng_site_api.fail_on_missing_field: '%kernel.debug%'
     ezsettings.default.ng_site_api.render_missing_field_info: false
+    ezsettings.default.ng_site_api.enable_internal_view_route: '%kernel.debug%'
+    ezsettings.default.ng_site_api.redirect_internal_view_route_to_url_alias: true
     ezsettings.default.ng_site_api.named_queries: []
     ezsettings.default.ng_site_api.named_objects: []
     ezsettings.default.ng_content_view: []

--- a/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/bundle/Resources/config/ezplatform_default_settings.yml
@@ -49,7 +49,7 @@ parameters:
     ezsettings.default.ng_site_api.show_hidden_items: false
     ezsettings.default.ng_site_api.fail_on_missing_field: '%kernel.debug%'
     ezsettings.default.ng_site_api.render_missing_field_info: false
-    ezsettings.default.ng_site_api.enable_internal_view_route: '%kernel.debug%'
+    ezsettings.default.ng_site_api.enable_internal_view_route: true
     ezsettings.default.ng_site_api.redirect_internal_view_route_to_url_alias: true
     ezsettings.default.ng_site_api.named_queries: []
     ezsettings.default.ng_site_api.named_objects: []

--- a/bundle/Resources/config/services/event_listener.yml
+++ b/bundle/Resources/config/services/event_listener.yml
@@ -6,6 +6,16 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    netgen.ezplatform_site.event_listener.internal_content_view_route:
+        class: Netgen\Bundle\EzPlatformSiteApiBundle\EventListener\InternalContentViewRouteListener
+        arguments:
+            - '@ezpublish.config.resolver'
+            - '@fragment.handler'
+            - '@router'
+            - '%ezpublish.siteaccess.groups%'
+        tags:
+            - { name: kernel.event_subscriber }
+
     netgen.ezplatform_site.event_listener.invalid_redirect_configuration:
         class: Netgen\Bundle\EzPlatformSiteApiBundle\EventListener\InvalidRedirectConfigurationListener
         public: false

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -190,6 +190,26 @@ opposite.
 
 .. _show_hidden_items_configuration:
 
+Internal Content View route on frontend siteaccesses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+eZ Platform allows use of internal Content View route from the admin UI on the frontend
+siteaccesses. That might not be desirable in all cases, so Site API provides two configuration
+options to control whether the internal route will be enabled on a frontend siteaccess and, if
+enabled, whether it will permanently (HTTP code 308) redirect to the URL alias.
+
+By default, both options are set to true and the route will be enabled and it will permanently
+redirect to the URL alias:
+
+.. code-block:: yaml
+
+    ezpublish:
+        system:
+            frontend_group:
+                ng_site_api:
+                    enable_internal_view_route: true
+                    redirect_internal_view_route_to_url_alias: true
+
 Configure showing hidden items
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
There a several problems with having Internal eZ Platform Content view route (`_ez_content_view`) on a frontend siteaccess:

- it generates the selected view using default templates from eZ Platform kernel
- it might present a security risk
  - it allows rendering of Content that might not be intended to be directly available (eg. various configuration objects)
  - it allows choosing a view and a Location
- it does not redirect to the URL alias route

This implementes rendering of the route through Site API and a configuration to control whether the route will be active on a frontend siteaccess and how it will behave (showing defaults):

```yaml
ezpublish:
    system:
        frontend_group:
            ng_site_api:
                enable_internal_view_route: true
                redirect_internal_view_route_to_url_alias: true
```

The route will be enabled by default and will permanently redirect to the URL alias. If disabled, or if the URL alias can't be generated, 404 will be thrown. If enabled without redirect, it will render the Content through the Site API, instead of using default eZ templates.