### PR TITLE
Improve query type expressions

### DIFF
--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -253,5 +253,16 @@ final class ParameterProcessor
                 return \array_values(\array_filter(\array_map('\trim', \explode($delimiter, $name))));
             }
         );
+
+        $expressionLanguage->register(
+            'fieldValue',
+            static function (): void {},
+            static function (array $arguments, string $fieldIdentifier) {
+                /** @var \Netgen\EzPlatformSiteApi\API\Values\Content $content */
+                $content = $arguments['content'];
+
+                return $content->getFieldValue($fieldIdentifier);
+            }
+        );
     }
 }

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -245,7 +245,7 @@ final class ParameterProcessor
         $expressionLanguage->register(
             'split',
             static function (): void {},
-            static function (array $arguments, string $name, string $delimiter) {
+            static function (array $arguments, string $name, string $delimiter = ',') {
                 if (empty($name)) {
                     return null;
                 }

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -250,7 +250,7 @@ final class ParameterProcessor
                     return null;
                 }
 
-                return \array_map('\trim', \explode($delimiter, $name));
+                return \array_values(\array_filter(\array_map('\trim', \explode($delimiter, $name))));
             }
         );
     }

--- a/lib/Core/Site/QueryType/Base.php
+++ b/lib/Core/Site/QueryType/Base.php
@@ -10,6 +10,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use InvalidArgumentException;
+use Netgen\EzPlatformSiteApi\API\Values\Location;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -255,8 +256,18 @@ abstract class Base implements QueryType
             }
         );
 
-        $class = SortClause::class;
-        $resolver->setAllowedTypes('sort', ['string', $class, 'array']);
+        $resolver->setAllowedTypes('sort', ['string', SortClause::class, Location::class, 'array']);
+
+        $resolver->setNormalizer(
+            'sort',
+            static function (Options $options, $value) {
+                if ($value instanceof Location) {
+                    return $value->innerLocation->getSortClauses();
+                }
+
+                return $value ?? [];
+            }
+        );
     }
 
     /**

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -240,8 +240,12 @@ final class ParameterProcessorTest extends TestCase
                 $this->getTagMock(),
             ],
             [
-                "@=split('pterodaktilivojka, grozdana,radoslava', ',')",
+                "@=split('pterodaktilivojka, grozdana,radoslava')",
                 ['pterodaktilivojka', 'grozdana', 'radoslava'],
+            ],
+            [
+                "@=split('burek, kifla,sirnica', ',')",
+                ['burek', 'kifla', 'sirnica'],
             ],
         ];
     }

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -247,6 +247,10 @@ final class ParameterProcessorTest extends TestCase
                 "@=split('burek, kifla,sirnica', ',')",
                 ['burek', 'kifla', 'sirnica'],
             ],
+            [
+                "@=split('  marmelada ::pekmez : đem:', ':')",
+                ['marmelada', 'pekmez', 'đem'],
+            ],
         ];
     }
 

--- a/tests/bundle/QueryType/ParameterProcessorTest.php
+++ b/tests/bundle/QueryType/ParameterProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Netgen\Bundle\EzPlatformSiteApiBundle\Tests\QueryType;
 
 use DateTime;
+use eZ\Publish\Core\FieldType\Integer\Value;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Netgen\Bundle\EzPlatformSiteApiBundle\NamedObject\Provider;
 use Netgen\Bundle\EzPlatformSiteApiBundle\QueryType\ParameterProcessor;
@@ -251,6 +252,10 @@ final class ParameterProcessorTest extends TestCase
                 "@=split('  marmelada ::pekmez : đem:', ':')",
                 ['marmelada', 'pekmez', 'đem'],
             ],
+            [
+                "@=fieldValue('buhtla').value",
+                5,
+            ],
         ];
     }
 
@@ -388,8 +393,8 @@ final class ParameterProcessorTest extends TestCase
                 ['paramExists', 123],
             ]);
 
-        $locationMock = $this->getMockBuilder(Location::class)->getMock();
-        $contentMock = $this->getMockBuilder(Content::class)->getMock();
+        $locationMock = $this->getLocationMock();
+        $contentMock = $this->getContentMock();
 
         $viewMock->method('getSiteLocation')->willReturn($locationMock);
         $viewMock->method('getSiteContent')->willReturn($contentMock);
@@ -403,6 +408,8 @@ final class ParameterProcessorTest extends TestCase
 
         if ($contentMock === null) {
             $contentMock = $this->getMockBuilder(Content::class)->getMock();
+
+            $contentMock->method('getFieldValue')->willReturn(new Value(5));
         }
 
         return $contentMock;

--- a/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
+++ b/tests/lib/Unit/Core/Site/QueryType/Location/SubtreeTest.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree as SubtreeCriterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Priority;
 use eZ\Publish\Core\Repository\Values\Content\Location as RepositoryLocation;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\Location\Subtree;
 use Netgen\EzPlatformSiteApi\Core\Site\QueryType\QueryType;
@@ -270,6 +271,21 @@ final class SubtreeTest extends QueryTypeBaseTest
                         new SubtreeCriterion('/3/5/7/11/'),
                         new LogicalNot(new LocationId(42)),
                     ]),
+                ]),
+            ],
+            [
+                [
+                    'location' => $location,
+                    'sort' => $location,
+                ],
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new SubtreeCriterion('/3/5/7/11/'),
+                        new LogicalNot(new LocationId(42)),
+                    ]),
+                    'sortClauses' => [
+                        new Priority(Query::SORT_DESC),
+                    ],
                 ]),
             ],
         ];


### PR DESCRIPTION
This adds some syntax sugar to Query Type expressions to make the configuration less verbose:
- `split` function now has `,` as a default delimiter and filters out delimiting mistakes
- `Location` instance is allowed as a sort option, converts to the Location's sort clauses
- `fieldValue(identifier)` function as a shortcut to `content.getFieldValue(identifier)`