### PR TITLE
Fix wrong condition in code examples for location priority

### DIFF
--- a/docs/reference/query_types/parameters/common/location/priority.rst.inc
+++ b/docs/reference/query_types/parameters/common/location/priority.rst.inc
@@ -16,11 +16,11 @@ Examples:
 .. code-block:: yaml
 
     # multiple operators are combined with logical AND
-    depth:
+    priority:
         gt: 4
         lte: 8
 
 .. code-block:: yaml
 
-    depth:
+    priority:
         between: [4, 7]


### PR DESCRIPTION
The code snippets on the page for locations' _priority_ condition contain mistakes: The examples don't actually use the `priority` condition. They currently use the `depth` condition instead.

This pull requests replaces uses of the `depth` condition with the `priority` condition being documented.