### PR TITLE
Fix RelationService method call examples

### DIFF
--- a/docs/reference/services.rst
+++ b/docs/reference/services.rst
@@ -254,7 +254,7 @@ supports optional filtering by ContentType.
 +----------------------------------------+------------------------------------------------------------------------------------+
 | **Example**                            | .. code-block:: php                                                                |
 |                                        |                                                                                    |
-|                                        |     $content = $relationService->getFieldRelation(                                 |
+|                                        |     $content = $relationService->loadFieldRelation(                                |
 |                                        |         $content,                                                                  |
 |                                        |         'relations',                                                               |
 |                                        |         ['articles']                                                               |
@@ -277,7 +277,7 @@ filtering by ContentType.
 +----------------------------------------+------------------------------------------------------------------------------------+
 | **Example**                            | .. code-block:: php                                                                |
 |                                        |                                                                                    |
-|                                        |     $contentItems = $relationService->getFieldRelations(                           |
+|                                        |     $contentItems = $relationService->loadFieldRelations(                          |
 |                                        |         $content,                                                                  |
 |                                        |         'relations',                                                               |
 |                                        |         ['articles']                                                               |
@@ -303,7 +303,7 @@ supports optional filtering by ContentType.
 +----------------------------------------+------------------------------------------------------------------------------------+
 | **Example**                            | .. code-block:: php                                                                |
 |                                        |                                                                                    |
-|                                        |     $content = $relationService->getFieldRelationLocation(                         |
+|                                        |     $content = $relationService->loadFieldRelationLocation(                        |
 |                                        |         $content,                                                                  |
 |                                        |         'relations',                                                               |
 |                                        |         ['articles']                                                               |
@@ -326,7 +326,7 @@ filtering by ContentType.
 +----------------------------------------+------------------------------------------------------------------------------------+
 | **Example**                            | .. code-block:: php                                                                |
 |                                        |                                                                                    |
-|                                        |     $contentItems = $relationService->getFieldRelationLocations(                   |
+|                                        |     $contentItems = $relationService->loadFieldRelationLocations(                  |
 |                                        |         $content,                                                                  |
 |                                        |         'relations',                                                               |
 |                                        |         ['articles']                                                               |


### PR DESCRIPTION
Documentation fix.

Page: [`Services/RelationService/Methods`](https://docs.netgen.io/projects/site-api/en/3.7/reference/services.html#id6)

### Problem:
In the examples for each method, the prefix is `get` instead of `load`.

### Fix:
Replaced `get` with `load` in the example method calls.