### PR TITLE
Require sensio/framework-extra-bundle at version ^5.5 or ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ezsystems/ezplatform-http-cache": "^2.2",
         "ezsystems/ezplatform-richtext": "^2.2",
         "netgen/ezplatform-search-extra": "^2.5",
-        "sensio/framework-extra-bundle": "^5.5"
+        "sensio/framework-extra-bundle": "^5.5|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Q | A
-- | --
Branch? | master
Bug fix? | no
New feature? | yes
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets? | #204

The purpose is to make this bundle compatible with the last version of Ibexa DXP, which requires `sensio/framework-extra-bundle` at version `^6.1`.

It seems that the only usage of `sensio/framework-extra-bundle` is for param converters, so there should not be any BC breaks.

This is my first PR ever, so don't hesitate to correct me if I'm wrong on the process. :)