### PR TITLE
Return an empty variation if image does not exist

### DIFF
--- a/bundle/Templating/Twig/Extension/ImageRuntime.php
+++ b/bundle/Templating/Twig/Extension/ImageRuntime.php
@@ -36,7 +36,7 @@ class ImageRuntime
     /**
      * Returns the image variation object for $field/$versionInfo.
      */
-    public function getImageVariation(Field $field, string $variationName): ?Variation
+    public function getImageVariation(Field $field, string $variationName): Variation
     {
         /** @var \eZ\Publish\Core\FieldType\Image\Value $value */
         $value = $field->value;
@@ -55,6 +55,6 @@ class ImageRuntime
             );
         }
 
-        return null;
+        return new Variation();
     }
 }


### PR DESCRIPTION
This prevents exceptions with `Impossible to access an attribute ("uri") on a null variable.` in Twig